### PR TITLE
[libknet] Use getrlimit instead of prlimit

### DIFF
--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -552,7 +552,7 @@ knet_handle_t knet_handle_new(uint16_t host_id,
 	int savederrno = 0;
 	struct rlimit cur;
 
-	if (prlimit(0, RLIMIT_NOFILE, NULL, &cur) < 0) {
+	if (getrlimit(RLIMIT_NOFILE, &cur) < 0) {
 		return NULL;
 	}
 

--- a/libknet/tests/api_knet_handle_new.c
+++ b/libknet/tests/api_knet_handle_new.c
@@ -63,7 +63,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if (prlimit(0, RLIMIT_NOFILE, NULL, &cur) < 0) {
+	if (getrlimit(RLIMIT_NOFILE, &cur) < 0) {
 		printf("Unable to get current fd limit: %s\n", strerror(errno));
 		exit(SKIP);
 	}


### PR DESCRIPTION
prlimit is Linux specific. Because passed pid is 0, we can replace
prlimit call by portable getrlimit without loose of functionality.

Signed-off-by: Jan Friesse jfriesse@redhat.com
