### PR TITLE
[build] Make sure lib64 is used when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,13 @@ if test "$prefix" = "NONE"; then
 	if test "$sysconfdir" = "\${prefix}/etc"; then
 		sysconfdir="/etc"
 	fi
+	if test "$libdir" = "\${exec_prefix}/lib"; then
+		if test -e /usr/lib64; then
+			libdir="/usr/lib64"
+		else
+			libdir="/usr/lib"
+		fi
+	fi
 fi
 
 # Checks for programs.


### PR DESCRIPTION
Default location for libraries is PREFIX/usr/lib. This doesn't work well
on systems with mixed 64 and 32-bit libs.

Signed-off-by: Jan Friesse jfriesse@redhat.com
