### PR TITLE
[libknet] Support systems without (send|recv)mmsg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,8 +163,13 @@ AC_CHECK_FUNCS([strrchr])
 AC_CHECK_FUNCS([strstr])
 AC_CHECK_FUNCS([clock_gettime])
 AC_CHECK_FUNCS([strcasecmp])
-AC_CHECK_FUNCS([sendmmsg], AC_MSG_RESULT([]), AC_MSG_ERROR([kernel 3.0+ and glibc 2.14+ are required]))
-AC_CHECK_FUNCS([recvmmsg], AC_MSG_RESULT([]), AC_MSG_ERROR([kernel 2.6.33 and glibc 2.12+ are required]))
+AC_CHECK_FUNCS([sendmmsg])
+AC_CHECK_FUNCS([recvmmsg])
+
+# Check entries in specific structs
+AC_CHECK_MEMBER([struct mmsghdr.msg_hdr],
+                [AC_DEFINE_UNQUOTED([HAVE_MMSGHDR], [1], [struct mmsghdr exists])],
+                [], [[#include <sys/socket.h>]])
 
 # PAM check
 AC_CHECK_HEADERS([security/pam_appl.h],

--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -21,6 +21,7 @@ libversion		= 0:0:0
 
 sources			= \
 			  common.c \
+			  compat.c \
 			  crypto.c \
 			  handle.c \
 			  host.c \
@@ -42,6 +43,7 @@ pkgconfig_DATA		= libknet.pc
 
 noinst_HEADERS		= \
 			  common.h \
+			  compat.h \
 			  crypto.h \
 			  host.h \
 			  internals.h \

--- a/libknet/compat.c
+++ b/libknet/compat.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.  All rights reserved.
+ *
+ * Author: Jan Friesse <jfriesse@redhat.com>
+ *
+ * This software licensed under GPL-2.0+, LGPL-2.0+
+ */
+
+#include "config.h"
+
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#include "compat.h"
+
+#ifndef HAVE_SENDMMSG
+int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
+    unsigned int flags)
+{
+#ifdef SYS_sendmmsg
+	/*
+	 * For systems where kernel supports sendmmsg but glibc doesn't (RHEL 6)
+	 */
+	return (syscall(SYS_sendmmsg, sockfd, msgvec, vlen, flags));
+#else
+	/*
+	 * Generic implementation of sendmmsg using sendmsg
+	 */
+	unsigned int i;
+	ssize_t ret;
+
+	if (vlen == 0) {
+		return (0);
+	}
+
+	for (i = 0; i < vlen; i++) {
+		ret = sendmsg(sockfd, &msgvec[i].msg_hdr, flags);
+		if (ret >= 0) {
+			msgvec[i].msg_len = ret;
+		} else {
+			break ;
+		}
+	}
+
+	return ((ret >= 0) ? vlen : ret);
+#endif
+}
+#endif
+
+#ifndef HAVE_RECVMMSG
+extern int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
+    unsigned int flags, struct timespec *timeout)
+{
+#ifdef SYS_recvmmsg
+	/*
+	 * For systems where kernel supports recvmmsg but glibc doesn't (RHEL 6)
+	 */
+	return (syscall(SYS_recvmmsg, sockfd, msgvec, vlen, flags, timeout));
+#else
+	/*
+	 * Generic implementation of recvmmsg using recvmsg
+	 */
+	unsigned int i;
+	ssize_t ret;
+
+	if (vlan == 0) {
+		return (0);
+	}
+
+	if (timeout != NULL || (flags && MSG_WAITFORONE)) {
+		/*
+		 * Not implemented
+		 */
+		errno = EINVAL;
+		return (-1);
+	}
+
+	for (i = 0; i < vlen; i++) {
+		ret = recvmsg(sockfd, &msgvec[i].msg_hdr, flags);
+		if (ret >= 0) {
+			msgvec[i].msg_len = ret;
+		} else {
+			break ;
+		}
+	}
+
+	return ((ret >= 0) ? vlen : ret);
+#endif
+}
+#endif

--- a/libknet/compat.h
+++ b/libknet/compat.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: Jan Friesse <jfriesse@redhat.com>
+ *
+ * This software licensed under GPL-2.0+, LGPL-2.0+
+ */
+
+#ifndef __COMPAT_H__
+#define __COMPAT_H__
+
+#include "config.h"
+#include <sys/socket.h>
+
+#ifndef HAVE_MMSGHDR
+struct mmsghdr {
+	struct msghdr msg_hdr;  /* Message header */
+	unsigned int  msg_len;  /* Number of bytes transmitted */
+};
+#endif
+
+#ifndef MSG_WAITFORONE
+#define MSG_WAITFORONE  0x10000
+#endif
+
+#ifndef HAVE_SENDMMSG
+extern int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
+    unsigned int flags);
+#endif
+
+#ifndef HAVE_RECVMMSG
+extern int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
+    unsigned int flags, struct timespec *timeout);
+#endif
+
+#endif


### PR DESCRIPTION
Implemented are generic (slightly reduced functionality) functions and
for systems with syscall available but libc prototypes unavailable
also syscall wrapper.

Signed-off-by: Jan Friesse jfriesse@redhat.com
