### PR TITLE
[libknet] Really use compat when needed

### DIFF
--- a/libknet/threads_send_recv.c
+++ b/libknet/threads_send_recv.c
@@ -21,6 +21,7 @@
 #include <netdb.h>
 
 #include "crypto.h"
+#include "compat.h"
 #include "host.h"
 #include "link.h"
 #include "logging.h"


### PR DESCRIPTION
Previous patch added compatatibility layer for systems without
(recv|send)mmsg but sadly forgot include compat.h when needed.

Signed-off-by: Jan Friesse jfriesse@redhat.com
