### PR TITLE
config: Make libtap & kronosnetd optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,16 @@ AC_PROG_RANLIB
 AC_CHECK_PROGS([PUBLICAN], [publican], [:])
 AC_CHECK_PROGS([PKGCONFIG], [pkg-config])
 
+AC_ARG_ENABLE([kronosnetd],
+        [  --enable-kronosnetd               : Kronosnetd support ],,
+        [ enable_kronosnetd="no" ])
+AM_CONDITIONAL([BUILD_KRONOSNETD], test x$enable_kronosnetd = xyes)
+
+AC_ARG_ENABLE([libtap],
+        [  --enable-libtap                   : libtap support ],,
+        [ enable_libtap="no" ])
+AM_CONDITIONAL([BUILD_LIBTAP], test x$enable_libtap = xyes)
+
 ## local helper functions
 # this function checks if CC support options passed as
 # args. Global CFLAGS are ignored during this test.
@@ -171,14 +181,18 @@ AC_CHECK_MEMBER([struct mmsghdr.msg_hdr],
                 [AC_DEFINE_UNQUOTED([HAVE_MMSGHDR], [1], [struct mmsghdr exists])],
                 [], [[#include <sys/socket.h>]])
 
-# PAM check
+# PAM check (for kronosnetd)
+if test "x$enable_kronosnetd" = xyes; then
 AC_CHECK_HEADERS([security/pam_appl.h],
 		 [AC_CHECK_LIB([pam], [pam_start])],
 		 [AC_MSG_ERROR([Unable to find LinuxPAM devel files])])
 
+
 AC_CHECK_HEADERS([security/pam_misc.h],
-		 [AC_CHECK_LIB([pam_misc], [misc_conv])],
-		 [AC_MSG_ERROR([Unable to find LinuxPAM MISC devel files])])
+	        [AC_CHECK_LIB([pam_misc], [misc_conv])],
+                [AC_MSG_ERROR([Unable to find LinuxPAM MISC devel files])])
+
+fi
 
 # local options
 AC_ARG_ENABLE([debug],

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,10 @@ AM_CONDITIONAL([BUILD_KRONOSNETD], test x$enable_kronosnetd = xyes)
 AC_ARG_ENABLE([libtap],
         [  --enable-libtap                   : libtap support ],,
         [ enable_libtap="no" ])
+
+if test "x$enable_kronosnetd" = xyes; then
+   enable_libtap=yes
+fi
 AM_CONDITIONAL([BUILD_LIBTAP], test x$enable_libtap = xyes)
 
 ## local helper functions

--- a/kronosnetd/Makefile.am
+++ b/kronosnetd/Makefile.am
@@ -10,6 +10,8 @@ MAINTAINERCLEANFILES	= Makefile.in kronostnetd.logrotate
 
 include $(top_srcdir)/build-aux/check.mk
 
+if BUILD_KRONOSNETD
+
 EXTRA_DIST		= kronosnetd.logrotate.in
 
 noinst_HEADERS		= \
@@ -86,3 +88,5 @@ uninstall-local:
 	rmdir $(DESTDIR)/$(sysconfdir)/logrotate.d || :;
 	rm -f $(DESTDIR)/$(sysconfdir)/pam.d/kronosnetd || :;
 	rmdir $(DESTDIR)/$(sysconfdir)/pam.d || :;
+
+endif

--- a/libtap/Makefile.am
+++ b/libtap/Makefile.am
@@ -10,9 +10,12 @@ MAINTAINERCLEANFILES	= Makefile.in
 
 include $(top_srcdir)/build-aux/check.mk
 
+
 SYMFILE			= libtap_exported_syms
 
 EXTRA_DIST		= $(SYMFILE) tap_updown_bad tap_updown_good api-test-coverage
+
+if BUILD_LIBTAP
 
 sources			= libtap.c
 
@@ -53,3 +56,5 @@ tap_test_SOURCES	= $(sources)
 
 tap_test_CPPFLAGS	= -DTEST \
 			  -DABSBUILDDIR=\"$(abs_builddir)\"
+
+endif


### PR DESCRIPTION
I've made them 'off' by default as that seems to make most sense. The PAM check is needed to get anywhere near building libknet on NetBSD ... not that we're very near that yet.
