### PR TITLE
Fix: remove duplicate judgement of (have_name < 0) in kronosnetd/vty_cli_cmds.c

### DIFF
--- a/kronosnetd/vty_cli_cmds.c
+++ b/kronosnetd/vty_cli_cmds.c
@@ -1091,8 +1091,8 @@ static int knet_find_host(struct knet_vty *vty,	const char *nodename, const knet
 	/*
 	 * internal error.. get out
 	 */
-	if ((have_nodeid < 0) || (have_name < 0)) {
-		knet_vty_write(vty, "Error: unable to query libknet for name/nodeid info%s", telnet_newline);
+	if (have_nodeid < 0) {
+		knet_vty_write(vty, "Error: unable to query libknet for nodeid info%s", telnet_newline);
 		return -1;
 	}
 


### PR DESCRIPTION
In line 1087 of kronosnetd/vty_cli_cmds.c, there is a judgement of
(have_name < 0), when have_name < 0, it will return 0, which make
the judge of have_name < 0 in line 1094 will never be executed.
Remove the unnecessary judgement.