### PR TITLE
Enable C99 language standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,12 @@ AC_PROG_GREP
 AC_PROG_SED
 AC_PROG_CPP
 AC_PROG_CC
-AM_PROG_CC_C_O
+AC_PROG_CC_C99
+if test "x$ac_cv_prog_cc_c99" = "xno"; then
+	AC_MSG_ERROR([C99 support is required])
+else
+	CFLAGS="-std=gnu99 $CFLAGS"
+fi
 AC_PROG_LN_S
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET


### PR DESCRIPTION
This allows, among other things, the following programming language features which I believe might be relevant to the development of Kronosnet:

- inline functions
- intermingled declarations and code (With a myriad of details for what this changes found on google).
- support for one-line comments beginning with //, as in BCPL, C++ and Java
- new library functions, such as snprintf
- new headers, such as <stdbool.h>, <complex.h>, <tgmath.h>, and <inttypes.h>
- designated initializers
- compound literals (for instance, it is possible to construct structures in function calls: function((struct x) {1, 2}))
- support for variadic macros (macros with a variable number of arguments)
- restrict qualification allows more aggressive code optimization, removing compile-time array access advantages previously held by FORTRAN over ANSI C[6]

