### PR TITLE
fix compile errors on i686

### DIFF
--- a/libknet/tests/api_knet_link_get_ping_timers.c
+++ b/libknet/tests/api_knet_link_get_ping_timers.c
@@ -167,7 +167,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	printf("DEFAULT: int: %zu timeout: %zu prec: %u\n", interval, timeout, precision);
+	printf("DEFAULT: int: %lu timeout: %lu prec: %u\n", interval, timeout, precision);
 
 	if ((interval != KNET_LINK_DEFAULT_PING_INTERVAL) ||
 	    (timeout != KNET_LINK_DEFAULT_PING_TIMEOUT) ||

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -258,7 +258,7 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 	}
 
 	if (len < (KNET_HEADER_SIZE + 1)) {
-		log_debug(knet_h, KNET_SUB_RX, "Packet is too short: %ld", len);
+		log_debug(knet_h, KNET_SUB_RX, "Packet is too short: %ld", (long)len);
 		return;
 	}
 


### PR DESCRIPTION
there are several compile errors on i686, although it is not very usual to use kronosnet/corosync on i686

threads_rx.c:261:34: error: format '%ld' expects argument of type 'long int', but argument 5 has type 'ssize_t {aka int}' [-Werror=format=]
   log_debug(knet_h, KNET_SUB_RX, "Packet is too short: %ld", len);
api_knet_link_get_ping_timers.c:170:26: error: format ‘%zu’ expects argument of type ‘size_t’, but argument 2 has type ‘time_t {aka long int}’ [-Werror=format=]
   printf("DEFAULT: int: %zu timeout: %zu prec: %u\n", interval, timeout, precision);

this request could fix the error both on i686 and runs smoothly on x86_64