### PR TITLE
Reconfigure warning settings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,36 +339,29 @@ EXTRA_WARNINGS=""
 
 WARNLIST="
 	all
+	extra
+	unused
 	shadow
 	missing-prototypes
 	missing-declarations
+	suggest-attribute=noreturn
+	suggest-attribute=format
 	strict-prototypes
-	declaration-after-statement
 	pointer-arith
 	write-strings
 	cast-align
 	bad-function-cast
 	missing-format-attribute
+	float-equal
 	format=2
-	format-security
-	format-nonliteral
-	no-long-long
-	unsigned-char
-	gnu89-inline
-	no-strict-aliasing
-	error
-	address
-	cpp
-	overflow
-	parentheses
-	sequence-point
-	switch
+	format-signedness
+	shift-overflow=2
+	overlength-strings
+	redundent-decls
+	init-self
 	uninitialized
-	unused-but-set-variable
-	unused-function
-	unused-result
-	unused-value
-	unused-variable
+	unknown-pragmas
+	no-unused-parameter
 	"
 
 for j in $WARNLIST; do

--- a/configure.ac
+++ b/configure.ac
@@ -355,11 +355,26 @@ WARNLIST="
 	float-equal
 	format=2
 	format-signedness
+	format-security
+	format-nonliteral
+	unsigned-char
+	error
+	address
+	cpp
+	overflow
+	parentheses
+	sequence-point
+	switch
 	shift-overflow=2
 	overlength-strings
 	redundent-decls
 	init-self
 	uninitialized
+	unused-but-set-variable
+	unused-function
+	unused-result
+	unused-value
+	unused-variable
 	unknown-pragmas
 	no-unused-parameter
 	"


### PR DESCRIPTION
Adds new warnings, and removes warning flags that are enabled by other warnings.

Note!!!! This pull request removes -Werror. I did this because there are new warnings introduced related to signed vs unsigned variables.

Please don't merge this pull request unless you're comfortable with -Werror being disabled.


See diff for comments on the specific changes