### PR TITLE
 libknet: Add link flag for 'hi' (interactive) priority

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -53,6 +53,15 @@ typedef uint16_t knet_node_id_t;
 #define KNET_NOTIFY_TX 0
 #define KNET_NOTIFY_RX 1
 
+
+/*
+ * Link flags
+ */
+
+/* Where possible, set traffic priority to high */
+#define KNET_LINK_FLAG_TRAFFICHIPRIO (1ULL << 0)
+
+
 typedef struct knet_handle *knet_handle_t;
 
 /*

--- a/libknet/tests/api_knet_link_get_config.c
+++ b/libknet/tests/api_knet_link_get_config.c
@@ -289,7 +289,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if (knet_link_set_config(knet_h, 1, 0, KNET_TRANSPORT_UDP, &src, NULL, 1) < 0) {
+	if (knet_link_set_config(knet_h, 1, 0, KNET_TRANSPORT_UDP, &src, NULL, KNET_LINK_FLAG_TRAFFICHIPRIO) < 0) {
 		printf("Unable to configure link: %s\n", strerror(errno));
 		knet_link_clear_config(knet_h, 1, 0);
 		knet_host_remove(knet_h, 1);
@@ -309,7 +309,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if (!flags) {
+	if (flags != KNET_LINK_FLAG_TRAFFICHIPRIO) {
 		printf("knet_link_get_config returned no flags\n");
 		knet_link_clear_config(knet_h, 1, 0);
 		knet_host_remove(knet_h, 1);

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -121,7 +121,7 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 #endif
 
 #ifdef SO_PRIORITY
-	if (flags && KNET_LINK_FLAG_TRAFFICHIPRIO) {
+	if (flags & KNET_LINK_FLAG_TRAFFICHIPRIO) {
 		value = 6; /* TC_PRIO_INTERACTIVE */
 		if (setsockopt(sock, SOL_SOCKET, SO_PRIORITY, &value, sizeof(value)) < 0) {
 			savederrno = errno;

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -61,7 +61,7 @@ int _sendmmsg(int sockfd, struct knet_mmsghdr *msgvec, unsigned int vlen, unsign
 	return ((i > 0) ? (int)i : err);
 }
 
-int _configure_common_socket(knet_handle_t knet_h, int sock, const char *type)
+int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, const char *type)
 {
 	int err = 0, savederrno = 0;
 	int value;
@@ -121,13 +121,15 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, const char *type)
 #endif
 
 #ifdef SO_PRIORITY
-	value = 6; /* TC_PRIO_INTERACTIVE */
-	if (setsockopt(sock, SOL_SOCKET, SO_PRIORITY, &value, sizeof(value)) < 0) {
-		savederrno = errno;
-		err = -1;
-		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s priority: %s",
-			type, strerror(savederrno));
-		goto exit_error;
+	if (flags && KNET_LINK_FLAG_TRAFFICHIPRIO) {
+		value = 6; /* TC_PRIO_INTERACTIVE */
+		if (setsockopt(sock, SOL_SOCKET, SO_PRIORITY, &value, sizeof(value)) < 0) {
+			savederrno = errno;
+			err = -1;
+			log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s priority: %s",
+				type, strerror(savederrno));
+			goto exit_error;
+		}
 	}
 #endif
 
@@ -136,12 +138,12 @@ exit_error:
 	return err;
 }
 
-int _configure_transport_socket(knet_handle_t knet_h, int sock, struct sockaddr_storage *address, const char *type)
+int _configure_transport_socket(knet_handle_t knet_h, int sock, struct sockaddr_storage *address, uint64_t flags, const char *type)
 {
 	int err = 0, savederrno = 0;
 	int value;
 
-	if (_configure_common_socket(knet_h, sock, type) < 0) {
+	if (_configure_common_socket(knet_h, sock, flags, type) < 0) {
 		savederrno = errno;
 		err = -1;
 		goto exit_error;
@@ -248,7 +250,7 @@ int _init_socketpair(knet_handle_t knet_h, int *sock)
 	}
 
 	for (i = 0; i < 2; i++) {
-		if (_configure_common_socket(knet_h, sock[i], "local socketpair") < 0) {
+		if (_configure_common_socket(knet_h, sock[i], 0, "local socketpair") < 0) {
 			savederrno = errno;
 			err = -1;
 			goto exit_fail;

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -148,7 +148,7 @@ static int _enable_sctp_notifications(knet_handle_t knet_h, int sock, const char
 	return err;
 }
 
-static int _configure_sctp_socket(knet_handle_t knet_h, int sock, struct sockaddr_storage *address, const char *type)
+static int _configure_sctp_socket(knet_handle_t knet_h, int sock, struct sockaddr_storage *address, uint64_t flags, const char *type)
 {
 	int err = 0, savederrno = 0;
 	int value;
@@ -160,7 +160,7 @@ static int _configure_sctp_socket(knet_handle_t knet_h, int sock, struct sockadd
 	level = IPPROTO_SCTP;
 #endif
 
-	if (_configure_transport_socket(knet_h, sock, address, type) < 0) {
+	if (_configure_transport_socket(knet_h, sock, address, flags, type) < 0) {
 		savederrno = errno;
 		err = -1;
 		goto exit_error;
@@ -238,7 +238,7 @@ static int _create_connect_socket(knet_handle_t knet_h, struct knet_link *kn_lin
 		goto exit_error;
 	}
 
-	if (_configure_sctp_socket(knet_h, connect_sock, &kn_link->dst_addr, "SCTP connect") < 0) {
+	if (_configure_sctp_socket(knet_h, connect_sock, &kn_link->dst_addr, kn_link->flags, "SCTP connect") < 0) {
 		savederrno = errno;
 		err = -1;
 		goto exit_error;
@@ -735,7 +735,7 @@ static void _handle_incoming_sctp(knet_handle_t knet_h, int listen_sock)
 		goto exit_error;
 	}
 
-	if (_configure_common_socket(knet_h, new_fd, "SCTP incoming") < 0) {
+	if (_configure_common_socket(knet_h, new_fd, 0, "SCTP incoming") < 0) { /* Inherit flags from listener? */
 		savederrno = errno;
 		err = -1;
 		goto exit_error;
@@ -937,7 +937,7 @@ static sctp_listen_link_info_t *sctp_link_listener_start(knet_handle_t knet_h, s
 		goto exit_error;
 	}
 
-	if (_configure_sctp_socket(knet_h, listen_sock, &kn_link->src_addr, "SCTP listener") < 0) {
+	if (_configure_sctp_socket(knet_h, listen_sock, &kn_link->src_addr, kn_link->flags, "SCTP listener") < 0) {
 		savederrno = errno;
 		err = -1;
 		goto exit_error;

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -74,7 +74,7 @@ static int udp_transport_link_set_config(knet_handle_t knet_h, struct knet_link 
 		goto exit_error;
 	}
 
-	if (_configure_transport_socket(knet_h, sock, &kn_link->src_addr, "UDP") < 0) {
+	if (_configure_transport_socket(knet_h, sock, &kn_link->src_addr, kn_link->flags, "UDP") < 0) {
 		savederrno = errno;
 		err = -1;
 		goto exit_error;

--- a/libknet/transports.h
+++ b/libknet/transports.h
@@ -12,8 +12,8 @@
 knet_transport_ops_t *get_udp_transport(void);
 knet_transport_ops_t *get_sctp_transport(void);
 
-int _configure_common_socket(knet_handle_t knet_h, int sock, const char *type);
-int _configure_transport_socket(knet_handle_t knet_h, int sock, struct sockaddr_storage *address, const char *type);
+int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, const char *type);
+int _configure_transport_socket(knet_handle_t knet_h, int sock, struct sockaddr_storage *address, uint64_t flags, const char *type);
 
 int _init_socketpair(knet_handle_t knet_h, int *sock);
 void _close_socketpair(knet_handle_t knet_h, int *sock);


### PR DESCRIPTION
Rather than being the default, this is now a link option.
Corosync needs it but other applications probably will not.

Any ideas for better names for the flag gratefully received.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>