### PR TITLE
libknet: Add link stats

### DIFF
--- a/kronosnetd/vty_cli_cmds.c
+++ b/kronosnetd/vty_cli_cmds.c
@@ -958,7 +958,7 @@ static int knet_cmd_no_link(struct knet_vty *vty)
 	get_param(vty, 1, &param, &paramlen, &paramoffset);
 	vty->link_id = param_to_int(param, paramlen);
 
-	knet_link_get_status(knet_iface->cfg_ring.knet_h, vty->host_id, vty->link_id, &status);
+	knet_link_get_status(knet_iface->cfg_ring.knet_h, vty->host_id, vty->link_id, &status, sizeof(status));
 
 	if (status.enabled) {
 		if (knet_link_set_enable(knet_iface->cfg_ring.knet_h, vty->host_id, vty->link_id, 0)) {
@@ -1004,7 +1004,7 @@ static int knet_cmd_link(struct knet_vty *vty)
 
 	transport_id = knet_handle_get_transport_id_by_name(knet_iface->cfg_ring.knet_h, transport);
 
-	knet_link_get_status(knet_iface->cfg_ring.knet_h, vty->host_id, vty->link_id, &status);
+	knet_link_get_status(knet_iface->cfg_ring.knet_h, vty->host_id, vty->link_id, &status, sizeof(status));
 	if (!status.enabled) {
 		if (knet_strtoaddr(src_ipaddr, src_port, &src_addr, sizeof(struct sockaddr_storage)) != 0) {
 			knet_vty_write(vty, "Error: unable to convert source ip addr to sockaddr!%s", telnet_newline);
@@ -1788,7 +1788,7 @@ static int knet_cmd_status(struct knet_vty *vty)
 
 				if (!knet_link_get_config(knet_iface->cfg_ring.knet_h, host_ids[j], link_ids[i], &transport, &src_addr, &dst_addr, &dynamic, &flags)) {
 					transport_name = knet_handle_get_transport_name_by_id(knet_iface->cfg_ring.knet_h, transport);
-					knet_link_get_status(knet_iface->cfg_ring.knet_h, host_ids[j], link_ids[i], &status);
+					knet_link_get_status(knet_iface->cfg_ring.knet_h, host_ids[j], link_ids[i], &status, sizeof(status));
 					if (status.enabled == 1) {
 						if (dynamic) {
 							knet_vty_write(vty, "    link %s dynamic (%s/connected: %d)%s", status.src_ipaddr, transport_name, status.connected, nl);
@@ -1903,7 +1903,7 @@ static int knet_cmd_print_conf(struct knet_vty *vty)
 
 				if (!knet_link_get_config(knet_iface->cfg_ring.knet_h, host_ids[j], link_ids[i], &transport, &src_addr, &dst_addr, &dynamic, &flags)) {
 					transport_name = knet_handle_get_transport_name_by_id(knet_iface->cfg_ring.knet_h, transport);
-					knet_link_get_status(knet_iface->cfg_ring.knet_h, host_ids[j], link_ids[i], &status);
+					knet_link_get_status(knet_iface->cfg_ring.knet_h, host_ids[j], link_ids[i], &status, sizeof(status));
 					if (status.enabled == 1) {
 						uint8_t priority, pong_count;
 						unsigned int precision;

--- a/libknet/host.c
+++ b/libknet/host.c
@@ -83,6 +83,7 @@ int knet_host_add(knet_handle_t knet_h, knet_node_id_t host_id)
 	 */
 	for (link_idx = 0; link_idx < KNET_MAX_LINK; link_idx++) {
 		host->link[link_idx].link_id = link_idx;
+		host->link[link_idx].status.stats.latency_min = UINT32_MAX;
 	}
 
 	/*

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -1290,25 +1290,53 @@ int knet_link_get_priority(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t
 int knet_link_get_link_list(knet_handle_t knet_h, knet_node_id_t host_id,
 			    uint8_t *link_ids, size_t *link_ids_entries);
 
+#define MAX_LINK_EVENTS 16
 struct knet_link_stats {
-	uint64_t tx_packets;
-	uint64_t rx_packets;
-	uint64_t tx_bytes;
-	uint64_t rx_bytes;
-	uint64_t rx_pings;
-	uint64_t tx_pings;
-	uint64_t rx_pongs;
-	uint64_t tx_pongs;
-	uint64_t rx_pmtu;
-	uint64_t tx_pmtu;
+	uint64_t tx_data_packets;
+	uint64_t rx_data_packets;
+	uint64_t tx_data_bytes;
+	uint64_t rx_data_bytes;
+	uint64_t rx_ping_packets;
+	uint64_t tx_ping_packets;
+	uint64_t rx_ping_bytes;
+	uint64_t tx_ping_bytes;
+	uint64_t rx_pong_packets;
+	uint64_t tx_pong_packets;
+	uint64_t rx_pong_bytes;
+	uint64_t tx_pong_bytes;
+	uint64_t rx_pmtu_packets;
+	uint64_t tx_pmtu_packets;
+	uint64_t rx_pmtu_bytes;
+	uint64_t tx_pmtu_bytes;
+
+	/* Only filled in when requested */
+	uint64_t tx_total_packets;
+	uint64_t rx_total_packets;
+	uint64_t tx_total_bytes;
+	uint64_t rx_total_bytes;
+	uint64_t tx_total_errors;
+	uint64_t tx_total_retries;
+
+	uint32_t tx_pmtu_errors;
+	uint32_t tx_pmtu_retries;
+	uint32_t tx_ping_errors;
+	uint32_t tx_ping_retries;
+	uint32_t tx_pong_errors;
+	uint32_t tx_pong_retries;
+	uint32_t tx_data_errors;
+	uint32_t tx_data_retries;
+
 	uint32_t latency_min;
 	uint32_t latency_max;
 	uint32_t latency_ave;
 	uint32_t latency_samples;
+
 	uint32_t down_count;
 	uint32_t up_count;
-	time_t   last_up_time;
-	time_t   last_down_time;
+	time_t   last_up_times[MAX_LINK_EVENTS];
+	time_t   last_down_times[MAX_LINK_EVENTS];
+	int8_t   last_up_time_index;
+	int8_t   last_down_time_index;
 	/* Always add new stats at the end */
 };
 

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -1290,6 +1290,28 @@ int knet_link_get_priority(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t
 int knet_link_get_link_list(knet_handle_t knet_h, knet_node_id_t host_id,
 			    uint8_t *link_ids, size_t *link_ids_entries);
 
+struct knet_link_stats {
+	uint64_t tx_packets;
+	uint64_t rx_packets;
+	uint64_t tx_bytes;
+	uint64_t rx_bytes;
+	uint64_t rx_pings;
+	uint64_t tx_pings;
+	uint64_t rx_pongs;
+	uint64_t tx_pongs;
+	uint64_t rx_pmtu;
+	uint64_t tx_pmtu;
+	uint32_t latency_min;
+	uint32_t latency_max;
+	uint32_t latency_ave;
+	uint32_t latency_samples;
+	uint32_t down_count;
+	uint32_t up_count;
+	time_t   last_up_time;
+	time_t   last_down_time;
+	/* Always add new stats at the end */
+};
+
 /*
  * define link status structure for quick lookup
  * struct is in flux as more stats will be added soon
@@ -1318,6 +1340,7 @@ int knet_link_get_link_list(knet_handle_t knet_h, knet_node_id_t host_id,
  */
 
 struct knet_link_status {
+	size_t size;                    /* For ABI checking */
 	char src_ipaddr[KNET_MAX_HOST_LEN];
 	char src_port[KNET_MAX_PORT_LEN];
 	char dst_ipaddr[KNET_MAX_HOST_LEN];
@@ -1336,7 +1359,8 @@ struct knet_link_status {
 					 * WARNING: in general mtu + proto_overhead might or might
 					 * not match the output of ifconfig mtu due to crypto
 					 * requirements to pad packets to some specific boundaries. */
-	/* add link statistics */
+	/* Link statistics */
+	struct knet_link_stats stats;
 };
 
 /*
@@ -1350,6 +1374,11 @@ struct knet_link_status {
  *
  * status    - pointer to knet_link_status struct (see above)
  *
+ * struct_size - max size of knet_link_status - allows library to
+ *               add fields without ABI change. Returned structure
+ *               will be truncated to this length and .size member
+ *               indicates the full size.
+ *
  * knet_link_get_status returns:
  *
  * 0 on success
@@ -1357,7 +1386,7 @@ struct knet_link_status {
  */
 
 int knet_link_get_status(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t link_id,
-			 struct knet_link_status *status);
+			 struct knet_link_status *status, size_t struct_size);
 
 /*
  * logging structs/API calls

--- a/libknet/tests/api_knet_link_get_status.c
+++ b/libknet/tests/api_knet_link_get_status.c
@@ -46,7 +46,7 @@ static void test(void)
 
 	memset(&status, 0, sizeof(struct knet_link_status));
 
-	if ((!knet_link_get_status(NULL, 1, 0, &status)) || (errno != EINVAL)) {
+	if ((!knet_link_get_status(NULL, 1, 0, &status, sizeof(struct knet_link_status))) || (errno != EINVAL)) {
 		printf("knet_link_get_status accepted invalid knet_h or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
@@ -64,7 +64,7 @@ static void test(void)
 
 	printf("Test knet_link_get_status with unconfigured host_id\n");
 
-	if ((!knet_link_get_status(knet_h, 1, 0, &status)) || (errno != EINVAL)) {
+	if ((!knet_link_get_status(knet_h, 1, 0, &status, sizeof(struct knet_link_status))) || (errno != EINVAL)) {
 		printf("knet_link_get_status accepted invalid host_id or returned incorrect error: %s\n", strerror(errno));
 		knet_handle_free(knet_h);
 		flush_logs(logfds[0], stdout);
@@ -84,7 +84,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if ((!knet_link_get_status(knet_h, 1, KNET_MAX_LINK, &status)) || (errno != EINVAL)) {
+	if ((!knet_link_get_status(knet_h, 1, KNET_MAX_LINK, &status, sizeof(struct knet_link_status))) || (errno != EINVAL)) {
 		printf("knet_link_get_status accepted invalid linkid or returned incorrect error: %s\n", strerror(errno));
 		knet_host_remove(knet_h, 1);
 		knet_handle_free(knet_h);
@@ -97,7 +97,7 @@ static void test(void)
 
 	printf("Test knet_link_get_status with incorrect status\n");
 
-	if ((!knet_link_get_status(knet_h, 1, 0, NULL)) || (errno != EINVAL)) {
+	if ((!knet_link_get_status(knet_h, 1, 0, NULL, 0)) || (errno != EINVAL)) {
 		printf("knet_link_get_status accepted invalid status or returned incorrect error: %s\n", strerror(errno));
 		knet_host_remove(knet_h, 1);
 		knet_handle_free(knet_h);
@@ -110,7 +110,7 @@ static void test(void)
 
 	printf("Test knet_link_get_status with unconfigured link\n");
 
-	if ((!knet_link_get_status(knet_h, 1, 0, &status)) || (errno != EINVAL)) {
+	if ((!knet_link_get_status(knet_h, 1, 0, &status, sizeof(struct knet_link_status))) || (errno != EINVAL)) {
 		printf("knet_link_get_status accepted unconfigured link or returned incorrect error: %s\n", strerror(errno));
 		knet_host_remove(knet_h, 1);
 		knet_handle_free(knet_h);
@@ -132,7 +132,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if (knet_link_get_status(knet_h, 1, 0, &status) < 0) {
+	if (knet_link_get_status(knet_h, 1, 0, &status, sizeof(struct knet_link_status)) < 0) {
 		printf("knet_link_get_status failed: %s\n", strerror(errno));
 		knet_link_clear_config(knet_h, 1, 0);
 		knet_host_remove(knet_h, 1);

--- a/libknet/tests/api_knet_link_set_config.c
+++ b/libknet/tests/api_knet_link_set_config.c
@@ -127,7 +127,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if (knet_link_get_status(knet_h, 1, 0, &link_status) < 0) {
+	if (knet_link_get_status(knet_h, 1, 0, &link_status, sizeof(struct knet_link_status)) < 0) {
 		printf("Unable to get link status: %s\n", strerror(errno));
 		knet_link_clear_config(knet_h, 1, 0);
 		knet_host_remove(knet_h, 1);
@@ -176,7 +176,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if (knet_link_get_status(knet_h, 1, 0, &link_status) < 0) {
+	if (knet_link_get_status(knet_h, 1, 0, &link_status, sizeof(struct knet_link_status)) < 0) {
 		printf("Unable to get link status: %s\n", strerror(errno));
 		knet_link_clear_config(knet_h, 1, 0);
 		knet_host_remove(knet_h, 1);
@@ -226,7 +226,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	if (knet_link_get_status(knet_h, 1, 0, &link_status) < 0) {
+	if (knet_link_get_status(knet_h, 1, 0, &link_status, sizeof(struct knet_link_status)) < 0) {
 		printf("Unable to get link status: %s\n", strerror(errno));
 		knet_link_clear_config(knet_h, 1, 0);
 		knet_host_remove(knet_h, 1);

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -409,7 +409,7 @@ int knet_handle_stop(knet_handle_t knet_h)
 			return -1;
 		}
 		for (j = 0; j < link_ids_entries; j++) {
-			if (knet_link_get_status(knet_h, host_ids[i], link_ids[j], &status)) {
+			if (knet_link_get_status(knet_h, host_ids[i], link_ids[j], &status, sizeof(struct knet_link_status))) {
 				printf("knet_link_get_status failed: %s\n", strerror(errno));
 				return -1;
 			}

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -88,7 +88,8 @@ retry:
 		savederrno = errno;
 
 		dst_link->ping_last = clock_now;
-		dst_link->status.stats.tx_pings++;
+		dst_link->status.stats.tx_ping_packets++;
+		dst_link->status.stats.tx_ping_bytes += outlen;
 
 		if (len != outlen) {
 			err = knet_h->transport_ops[dst_link->transport_type]->transport_tx_sock_error(knet_h, dst_link->outsock, len, savederrno);
@@ -99,10 +100,12 @@ retry:
 						  dst_link->outsock, savederrno, strerror(savederrno),
 						  dst_link->status.src_ipaddr, dst_link->status.src_port,
 						  dst_link->status.dst_ipaddr, dst_link->status.dst_port);
+					dst_link->status.stats.tx_ping_errors++;
 					break;
 				case 0:
 					break;
 				case 1:
+					dst_link->status.stats.tx_ping_retries++;
 					goto retry;
 					break;
 			}

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -88,6 +88,7 @@ retry:
 		savederrno = errno;
 
 		dst_link->ping_last = clock_now;
+		dst_link->status.stats.tx_pings++;
 
 		if (len != outlen) {
 			err = knet_h->transport_ops[dst_link->transport_type]->transport_tx_sock_error(knet_h, dst_link->outsock, len, savederrno);

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -183,6 +183,7 @@ retry:
 	} else {
 		dst_link->last_sent_mtu = onwire_len;
 		dst_link->last_recv_mtu = 0;
+		dst_link->status.stats.tx_pmtu++;
 
 		if (clock_gettime(CLOCK_REALTIME, &ts) < 0) {
 			log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get current time: %s", strerror(errno));

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -520,7 +520,6 @@ retry_pong:
 						  src_link->status.dst_ipaddr, src_link->status.dst_port);
 					src_link->status.stats.tx_pong_errors++;
 					break;
-					src_link->status.stats.tx_pong_errors++;
 				case 0: /* ignore error and continue */
 					break;
 				case 1: /* retry to send those same data */

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -277,9 +277,9 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 
 	src_link = NULL;
 
+	src_link = src_host->link +
+		(inbuf->khp_ping_link % KNET_MAX_LINK);
 	if ((inbuf->kh_type & KNET_HEADER_TYPE_PMSK) != 0) {
-		src_link = src_host->link +
-				(inbuf->khp_ping_link % KNET_MAX_LINK);
 		if (src_link->dynamic == KNET_LINK_DYNIP) {
 			/*
 			 * cpyaddrport will only copy address and port of the incoming
@@ -328,6 +328,11 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 		inbuf->khp_data_seq_num = ntohs(inbuf->khp_data_seq_num);
 		channel = inbuf->khp_data_channel;
 		src_host->got_data = 1;
+
+		if (src_link) {
+			src_link->status.stats.rx_packets++;
+			src_link->status.stats.rx_bytes += len;
+		}
 
 		if (!_seq_num_lookup(src_host, inbuf->khp_data_seq_num, 0, 0)) {
 			if (src_host->link_handler_policy != KNET_LINK_POLICY_ACTIVE) {
@@ -445,6 +450,7 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 		inbuf->kh_type = KNET_HEADER_TYPE_PONG;
 		inbuf->kh_node = htons(knet_h->host_id);
 		recv_seq_num = ntohs(inbuf->khp_ping_seq_num);
+		src_link->status.stats.rx_pings++;
 
 		wipe_bufs = 0;
 
@@ -519,8 +525,10 @@ retry_pong:
 					break;
 			}
 		}
+		src_link->status.stats.tx_pongs++;
 		break;
 	case KNET_HEADER_TYPE_PONG:
+		src_link->status.stats.rx_pongs++;
 		clock_gettime(CLOCK_MONOTONIC, &src_link->status.pong_last);
 
 		memmove(&recvtime, &inbuf->khp_ping_time[0], sizeof(struct timespec));
@@ -546,9 +554,21 @@ retry_pong:
 				}
 			}
 		}
+		/* Calculate latency stats */
+		if (src_link->status.latency > src_link->status.stats.latency_max) {
+			src_link->status.stats.latency_max = src_link->status.latency;
+		}
+		if (src_link->status.latency < src_link->status.stats.latency_min) {
+			src_link->status.stats.latency_min = src_link->status.latency;
+		}
+		src_link->status.stats.latency_ave =
+			(src_link->status.stats.latency_ave * src_link->status.stats.latency_samples +
+			 src_link->status.latency) / (src_link->status.stats.latency_samples+1);
+		src_link->status.stats.latency_samples++;
 
 		break;
 	case KNET_HEADER_TYPE_PMTUD:
+		src_link->status.stats.rx_pmtu++;
 		outlen = KNET_HEADER_PMTUD_SIZE;
 		inbuf->kh_type = KNET_HEADER_TYPE_PMTUD_REPLY;
 		inbuf->kh_node = htons(knet_h->host_id);
@@ -589,6 +609,7 @@ retry_pmtud:
 
 		break;
 	case KNET_HEADER_TYPE_PMTUD_REPLY:
+		src_link->status.stats.rx_pmtu++;
 		if (pthread_mutex_lock(&knet_h->pmtud_mutex) != 0) {
 			log_debug(knet_h, KNET_SUB_RX, "Unable to get mutex lock");
 			break;

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -34,16 +34,24 @@ static int _dispatch_to_links(knet_handle_t knet_h, struct knet_host *dst_host, 
 {
 	int link_idx, msg_idx, sent_msgs, prev_sent, progress;
 	int err = 0, savederrno = 0;
+	unsigned int i;
 	struct knet_mmsghdr *cur;
+	struct knet_link *cur_link;
 
 	for (link_idx = 0; link_idx < dst_host->active_link_entries; link_idx++) {
 		sent_msgs = 0;
 		prev_sent = 0;
 		progress = 1;
 
+		cur_link = &dst_host->link[dst_host->active_links[link_idx]];
 		msg_idx = 0;
 		while (msg_idx < msgs_to_send) {
-			msg[msg_idx].msg_hdr.msg_name = &dst_host->link[dst_host->active_links[link_idx]].dst_addr;
+			msg[msg_idx].msg_hdr.msg_name = &cur_link->dst_addr;
+
+			for (i=0; i<msg[msg_idx].msg_hdr.msg_iovlen; i++) {
+				cur_link->status.stats.tx_bytes += msg[msg_idx].msg_hdr.msg_iov[i].iov_len;
+			}
+			cur_link->status.stats.tx_packets++;
 			msg_idx++;
 		}
 

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -49,9 +49,9 @@ static int _dispatch_to_links(knet_handle_t knet_h, struct knet_host *dst_host, 
 			msg[msg_idx].msg_hdr.msg_name = &cur_link->dst_addr;
 
 			for (i=0; i<msg[msg_idx].msg_hdr.msg_iovlen; i++) {
-				cur_link->status.stats.tx_bytes += msg[msg_idx].msg_hdr.msg_iov[i].iov_len;
+				cur_link->status.stats.tx_data_bytes += msg[msg_idx].msg_hdr.msg_iov[i].iov_len;
 			}
-			cur_link->status.stats.tx_packets++;
+			cur_link->status.stats.tx_data_packets++;
 			msg_idx++;
 		}
 
@@ -65,11 +65,13 @@ retry:
 		err = knet_h->transport_ops[dst_host->link[dst_host->active_links[link_idx]].transport_type]->transport_tx_sock_error(knet_h, dst_host->link[dst_host->active_links[link_idx]].outsock, sent_msgs, savederrno);
 		switch(err) {
 			case -1: /* unrecoverable error */
+				cur_link->status.stats.tx_data_errors++;
 				goto out_unlock;
 				break;
 			case 0: /* ignore error and continue */
 				break;
 			case 1: /* retry to send those same data */
+				cur_link->status.stats.tx_data_retries++;
 				goto retry;
 				break;
 		}


### PR DESCRIPTION
This patch also includes an ABI change to knet_link_get_status()
(as well as returning a load of stats) that should allow us to
add more stats at a later stage without ballooning memory use
with pads or crashing earlier-linked programs with structure
overwrites.