### PR TITLE
Fips enable

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -579,7 +579,7 @@ int knet_handle_pmtud_get(knet_handle_t knet_h,
  * -2 on crypto subsystem initialization error. No errno is provided at the moment (yet).
  */
 
-#define KNET_MIN_KEY_LEN 1024
+#define KNET_MIN_KEY_LEN  256
 #define KNET_MAX_KEY_LEN 4096
 
 struct knet_handle_crypto_cfg {

--- a/libknet/nsscrypto.c
+++ b/libknet/nsscrypto.c
@@ -109,6 +109,11 @@ size_t hash_len[] = {
 	SHA512_LENGTH			/* CRYPTO_HASH_TYPE_SHA512 */
 };
 
+enum sym_key_type {
+	SYM_KEY_TYPE_CRYPT,
+	SYM_KEY_TYPE_HASH
+};
+
 struct nsscrypto_instance {
 	PK11SymKey   *nss_sym_key;
 	PK11SymKey   *nss_sym_key_sign;
@@ -142,38 +147,64 @@ static int string_to_crypto_cipher_type(const char* crypto_cipher_type)
 	return -1;
 }
 
+static PK11SymKey *import_symmetric_key(knet_handle_t knet_h, enum sym_key_type key_type)
+{
+	struct nsscrypto_instance *instance = knet_h->crypto_instance->model_instance;
+	SECItem key_item;
+	PK11SlotInfo *slot;
+	PK11SymKey *res_key;
+	CK_MECHANISM_TYPE cipher;
+	CK_ATTRIBUTE_TYPE operation;
+
+	memset(&key_item, 0, sizeof(key_item));
+	slot = NULL;
+
+	key_item.type = siBuffer;
+	key_item.data = instance->private_key;
+
+	switch (key_type) {
+	case SYM_KEY_TYPE_CRYPT:
+		key_item.len = cipher_key_len[instance->crypto_cipher_type];
+		cipher = cipher_to_nss[instance->crypto_cipher_type];
+		operation = CKA_ENCRYPT|CKA_DECRYPT;
+		break;
+	case SYM_KEY_TYPE_HASH:
+		key_item.len = instance->private_key_len;
+		cipher = hash_to_nss[instance->crypto_hash_type];
+		operation = CKA_SIGN;
+		break;
+	}
+
+	slot = PK11_GetBestSlot(cipher, NULL);
+	if (slot == NULL) {
+		log_err(knet_h, KNET_SUB_NSSCRYPTO, "Unable to find security slot (%d): %s",
+			   PR_GetError(), PR_ErrorToString(PR_GetError(), PR_LANGUAGE_I_DEFAULT));
+		return (NULL);
+	}
+
+	res_key = PK11_ImportSymKey(slot, cipher, PK11_OriginUnwrap, operation, &key_item, NULL);
+	if (res_key == NULL) {
+		log_err(knet_h, KNET_SUB_NSSCRYPTO, "Failure to import key into NSS (%d): %s",
+			   PR_GetError(), PR_ErrorToString(PR_GetError(), PR_LANGUAGE_I_DEFAULT));
+		goto exit_err;
+	}
+exit_err:
+	PK11_FreeSlot(slot);
+	return (res_key);
+}
+
 static int init_nss_crypto(knet_handle_t knet_h)
 {
-	PK11SlotInfo*	crypt_slot = NULL;
-	SECItem		crypt_param;
 	struct nsscrypto_instance *instance = knet_h->crypto_instance->model_instance;
 
 	if (!cipher_to_nss[instance->crypto_cipher_type]) {
 		return 0;
 	}
 
-	crypt_param.type = siBuffer;
-	crypt_param.data = instance->private_key;
-	crypt_param.len = cipher_key_len[instance->crypto_cipher_type];
-
-	crypt_slot = PK11_GetBestSlot(cipher_to_nss[instance->crypto_cipher_type], NULL);
-	if (crypt_slot == NULL) {
-		log_err(knet_h, KNET_SUB_NSSCRYPTO, "Unable to find security slot (err %d)",
-			   PR_GetError());
-		return -1;
-	}
-
-	instance->nss_sym_key = PK11_ImportSymKey(crypt_slot,
-						  cipher_to_nss[instance->crypto_cipher_type],
-						  PK11_OriginUnwrap, CKA_ENCRYPT|CKA_DECRYPT,
-						  &crypt_param, NULL);
+	instance->nss_sym_key = import_symmetric_key(knet_h, SYM_KEY_TYPE_CRYPT);
 	if (instance->nss_sym_key == NULL) {
-		log_err(knet_h, KNET_SUB_NSSCRYPTO, "Failure to import key into NSS (err %d)",
-			   PR_GetError());
 		return -1;
 	}
-
-	PK11_FreeSlot(crypt_slot);
 
 	return 0;
 }
@@ -347,36 +378,16 @@ static int string_to_crypto_hash_type(const char* crypto_hash_type)
 
 static int init_nss_hash(knet_handle_t knet_h)
 {
-	PK11SlotInfo*	hash_slot = NULL;
-	SECItem		hash_param;
 	struct nsscrypto_instance *instance = knet_h->crypto_instance->model_instance;
 
 	if (!hash_to_nss[instance->crypto_hash_type]) {
 		return 0;
 	}
 
-	hash_param.type = siBuffer;
-	hash_param.data = instance->private_key;
-	hash_param.len = instance->private_key_len;
-
-	hash_slot = PK11_GetBestSlot(hash_to_nss[instance->crypto_hash_type], NULL);
-	if (hash_slot == NULL) {
-		log_err(knet_h, KNET_SUB_NSSCRYPTO, "Unable to find security slot (err %d)",
-			   PR_GetError());
-		return -1;
-	}
-
-	instance->nss_sym_key_sign = PK11_ImportSymKey(hash_slot,
-						       hash_to_nss[instance->crypto_hash_type],
-						       PK11_OriginUnwrap, CKA_SIGN,
-						       &hash_param, NULL);
+	instance->nss_sym_key_sign = import_symmetric_key(knet_h, SYM_KEY_TYPE_HASH);
 	if (instance->nss_sym_key_sign == NULL) {
-		log_err(knet_h, KNET_SUB_NSSCRYPTO, "Failure to import key into NSS (err %d)",
-			   PR_GetError());
 		return -1;
 	}
-
-	PK11_FreeSlot(hash_slot);
 
 	return 0;
 }


### PR DESCRIPTION
"Backported" corosync patches with same functionality.

I had to implement workaround because softtoken doesn't accept symkeys larger than 256 bytes. Other solutions may be:
- Make NSS softtoken support symkey with keys larger than 256 bytes (file issue/...)
- Decrase knet key lengths
