### PR TITLE
libknet: Optimised path for local traffic

### DIFF
--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -180,6 +180,8 @@ struct knet_handle {
 	unsigned char *pmtudbuf_crypt;
 	seq_num_t tx_seq_num;
 	pthread_mutex_t tx_seq_num_mutex;
+	uint8_t allow_local_send;
+	struct knet_link_status local_send_stats;
 	void *dst_host_filter_fn_private_data;
 	int (*dst_host_filter_fn) (
 		void *private_data,


### PR DESCRIPTION
In corosync I bypassed knet for local traffic by sending to datafd+1,
this adds that functionality back into knet to avoid exceptions in
client code and allow us to keep statistics on local traffic.

This only happens if link 0 on the local host is enabled and can be
disabled by disabling that 'link'. There is no actual link of course
just a short-cut send.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>