### PR TITLE
loopback: Only allow 1 link to localhost if loopback is used.

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -941,7 +941,8 @@ int knet_addrtostr(const struct sockaddr_storage *ss, socklen_t sslen,
  * type is allowed. Data sent down a LOOPBACK link will be copied directly from
  * the knet send datafd to the knet receive datafd so the application must be set
  * up to take data from that socket at least as often as it is sent or deadlocks
- * could occur.
+ * could occur. If used, a LOOPBACK link must be the only link configured to the
+ * local host.
  */
 
 struct transport_info {

--- a/libknet/link.c
+++ b/libknet/link.c
@@ -100,14 +100,14 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	if (transport == KNET_TRANSPORT_LOOPBACK && knet_h->host_id != host_id) {
 		log_err(knet_h, KNET_SUB_LINK, "Cannot create loopback link to remote node");
 		err = -1;
-		errno = EINVAL;
+		savederrno = EINVAL;
 		goto exit_unlock;
 	}
 
 	if (knet_h->host_id == host_id && knet_h->has_loop_link) {
 		log_err(knet_h, KNET_SUB_LINK, "Cannot create more than 1 link when loopback is active");
 		err = -1;
-		errno = EINVAL;
+		savederrno = EINVAL;
 		goto exit_unlock;
 	}
 
@@ -125,7 +125,7 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 			if (host->link[i].configured) {
 				log_err(knet_h, KNET_SUB_LINK, "Cannot add loopback link when other links are already configured.");
 				err = -1;
-				errno = EINVAL;
+				savederrno = EINVAL;
 				goto exit_unlock;
 			}
 		}


### PR DESCRIPTION
If loopback is configured as a link transport to localhost then
no other transport makes sense and could actually cause
duplicate packets to be received. So now it's enforced and tested.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>