### PR TITLE
[udp] fix incorrect return code

### DIFF
--- a/kronosnet.spec.in
+++ b/kronosnet.spec.in
@@ -76,6 +76,7 @@ Source0: https://github.com/fabbione/kronosnet/archive/%{name}-%{version}%{?numc
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 # Build dependencies
+BuildRequires: gcc
 %if %{defined buildsctp}
 BuildRequires: lksctp-tools-devel
 %endif

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -357,18 +357,18 @@ static int udp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int rec
 static int udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
 {
 	if (recv_err < 0) {
+		if (recv_errno == EMSGSIZE) {
+			return 0;
+		}
 		if ((recv_errno == ENOBUFS) || (recv_errno == EAGAIN)) {
 #ifdef DEBUG
 			log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is overloaded. Slowing TX down", sockfd);
 #endif
 			usleep(KNET_THREADS_TIMERES / 16);
-			return 1;
+		} else {
+			read_errs_from_sock(knet_h, sockfd);
 		}
-		read_errs_from_sock(knet_h, sockfd);
-		if (recv_errno == EMSGSIZE) {
-			return 0;
-		}
-		return -1;
+		return 1;
 	}
 
 	return 0;


### PR DESCRIPTION
UDP TX is tricky and racy and in theory TX never fails, as UDP is allowed
to drop packets internally anyway.

In some race condition situations, we can endup in a situation where:
- thread X attempts to send a packet
- socket receives an ICMP back (for whatever reasons) generated
  by some other random thread/packet combo
- thread X detects an error in TX and decode the error (correct)

pre patch:
- thread X would treat that as error and drop the packet
post patch:
- thread X should simply resend the packet

simply also the ordering of parsing socket error code to make it easier to read

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>