### PR TITLE
Added 'gcc' to .spec BuildRequires

### DIFF
--- a/kronosnet.spec.in
+++ b/kronosnet.spec.in
@@ -76,6 +76,7 @@ Source0: https://github.com/fabbione/kronosnet/archive/%{name}-%{version}%{?numc
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 # Build dependencies
+BuildRequires: gcc
 %if %{defined buildsctp}
 BuildRequires: lksctp-tools-devel
 %endif


### PR DESCRIPTION
Needed because gcc isn't installed by default on fedora 26 minimal.