### PR TITLE
[libknet] rename transport_info to knet_transport_info

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -1194,7 +1194,7 @@ int knet_addrtostr(const struct sockaddr_storage *ss, socklen_t sslen,
  * local host.
  */
 
-struct transport_info {
+struct knet_transport_info {
 	const char *name;   /* UDP/SCTP/etc... */
 	uint8_t id;         /* value that can be used for link_set_config */
 	uint8_t properties; /* currently unused */
@@ -1220,7 +1220,8 @@ struct transport_info {
  */
 
 int knet_handle_get_transport_list(knet_handle_t knet_h,
-				   struct transport_info *transport_list, size_t *transport_list_entries);
+				   struct knet_transport_info *transport_list,
+				   size_t *transport_list_entries);
 
 /**
  * knet_handle_get_transport_name_by_id

--- a/libknet/man/knet_handle_get_transport_list.3
+++ b/libknet/man/knet_handle_get_transport_list.3
@@ -8,9 +8,9 @@ knet_handle_get_transport_list \- Get a list of the transports support by this b
 .B #include <libknet.h>
 .sp
 \fBint knet_handle_get_transport_list\fP(
-    \fBknet_handle_t           \fP\fIknet_h\fP,
-    \fBstruct transport_info  *\fP\fItransport_list\fP,
-    \fBsize_t                 *\fP\fItransport_list_entries\fP
+    \fBknet_handle_t                \fP\fIknet_h\fP,
+    \fBstruct knet_transport_info  *\fP\fItransport_list\fP,
+    \fBsize_t                      *\fP\fItransport_list_entries\fP
 );
 .fi
 .SH DESCRIPTION
@@ -30,7 +30,7 @@ transport_list_entries - pointer to a size_t where to store how many transports 
 .RS
 .nf
 \fB
-struct transport_info {
+struct knet_transport_info {
   const char  *\fIname\fP;
   uint8_t      \fIid\fP;
   uint8_t      \fIproperties\fP;

--- a/libknet/man/libknet.h.3
+++ b/libknet/man/libknet.h.3
@@ -30,7 +30,7 @@ int           knet_handle_get_crypto_list(knet_handle_t, const char **, size_t *
 int           knet_handle_get_datafd(knet_handle_t, const int8_t, int *);
 int           knet_handle_get_stats(knet_handle_t, struct knet_handle_stats *, size_t);
 uint8_t       knet_handle_get_transport_id_by_name(knet_handle_t, const char *);
-int           knet_handle_get_transport_list(knet_handle_t, struct transport_info *, size_t *);
+int           knet_handle_get_transport_list(knet_handle_t, struct knet_transport_info *, size_t *);
 const char   *knet_handle_get_transport_name_by_id(knet_handle_t, uint8_t);
 int           knet_handle_get_transport_reconnect_interval(knet_handle_t, uint32_t *);
 knet_handle_t knet_handle_new(knet_node_id_t, int, uint8_t);
@@ -73,6 +73,31 @@ ssize_t       knet_recv(knet_handle_t, char *, const size_t, const int8_t);
 ssize_t       knet_send(knet_handle_t, const char *, const size_t, const int8_t);
 int           knet_send_sync(knet_handle_t, const char *, const size_t, const int8_t);
 int           knet_strtoaddr(const char *, const char *, struct sockaddr_storage *, socklen_t);
+\fP
+.fi
+.RE
+.SS ""
+.PP
+.sp
+.sp
+.RS
+.nf
+\fB
+struct knet_link_status {
+  size_t                 \fIsize\fP;
+  char                   \fIsrc_ipaddr\fP;
+  char                   \fIsrc_port\fP;
+  char                   \fIdst_ipaddr\fP;
+  char                   \fIdst_port\fP;
+  uint8_t                \fIenabled\fP;
+  uint8_t                \fIconnected\fP;
+  uint8_t                \fIdynconnected\fP;
+  unsigned long long     \fIlatency\fP;
+  struct timespec        \fIpong_last\fP;
+  unsigned int           \fImtu\fP;
+  unsigned int           \fIproto_overhead\fP;
+  struct knet_link_stats \fIstats\fP;
+};
 \fP
 .fi
 .RE
@@ -135,7 +160,22 @@ struct knet_handle_stats {
 .RS
 .nf
 \fB
-struct transport_info {
+struct knet_host_status {
+  uint8_t  \fIreachable\fP;
+  uint8_t  \fIremote\fP;
+  uint8_t  \fIexternal\fP;
+};
+\fP
+.fi
+.RE
+.SS ""
+.PP
+.sp
+.sp
+.RS
+.nf
+\fB
+struct knet_transport_info {
   const char  *\fIname\fP;
   uint8_t      \fIid\fP;
   uint8_t      \fIproperties\fP;
@@ -154,46 +194,6 @@ struct knet_handle_compress_cfg {
   char     \fIcompress_model\fP;
   uint32_t \fIcompress_threshold\fP;
   int      \fIcompress_level\fP;
-};
-\fP
-.fi
-.RE
-.SS ""
-.PP
-.sp
-.sp
-.RS
-.nf
-\fB
-struct knet_host_status {
-  uint8_t  \fIreachable\fP;
-  uint8_t  \fIremote\fP;
-  uint8_t  \fIexternal\fP;
-};
-\fP
-.fi
-.RE
-.SS ""
-.PP
-.sp
-.sp
-.RS
-.nf
-\fB
-struct knet_link_status {
-  size_t                 \fIsize\fP;
-  char                   \fIsrc_ipaddr\fP;
-  char                   \fIsrc_port\fP;
-  char                   \fIdst_ipaddr\fP;
-  char                   \fIdst_port\fP;
-  uint8_t                \fIenabled\fP;
-  uint8_t                \fIconnected\fP;
-  uint8_t                \fIdynconnected\fP;
-  unsigned long long     \fIlatency\fP;
-  struct timespec        \fIpong_last\fP;
-  unsigned int           \fImtu\fP;
-  unsigned int           \fIproto_overhead\fP;
-  struct knet_link_stats \fIstats\fP;
 };
 \fP
 .fi

--- a/libknet/tests/api_knet_handle_get_transport_list.c
+++ b/libknet/tests/api_knet_handle_get_transport_list.c
@@ -23,7 +23,7 @@ static void test(void)
 {
 	knet_handle_t knet_h;
 	int logfds[2];
-	struct transport_info transport_list[KNET_MAX_TRANSPORTS];
+	struct knet_transport_info transport_list[KNET_MAX_TRANSPORTS];
 	size_t transport_list_entries;
 	size_t i, expected_count;
 

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -344,7 +344,8 @@ int _set_fd_tracker(knet_handle_t knet_h, int sockfd, uint8_t transport, uint8_t
  */
 
 int knet_handle_get_transport_list(knet_handle_t knet_h,
-				   struct transport_info *transport_list, size_t *transport_list_entries)
+				   struct knet_transport_info *transport_list,
+				   size_t *transport_list_entries)
 {
 	int err = 0, savederrno = 0;
 	int i, count;


### PR DESCRIPTION
match the namespace of all our struct. This is an API change, but doesn't affect ABI.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>