### PR TITLE
[bsd] fix builds and testsuite on BSD x86_64/i386

### DIFF
--- a/build-aux/knet_valgrind_memcheck.supp
+++ b/build-aux/knet_valgrind_memcheck.supp
@@ -476,3 +476,51 @@
    fun:_handle_send_to_links_thread
    fun:start_thread
 }
+{
+   nss internal stuff (FreeBSD 11.1)
+   Memcheck:Addr8
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   fun:PR_LoadLibraryWithFlags
+   obj:/usr/local/lib/nss/libnssutil3.so
+   fun:PORT_LoadLibraryFromOrigin
+   obj:/usr/local/lib/nss/libnss3.so
+   fun:PR_CallOnce
+   obj:/usr/local/lib/nss/libnss3.so
+}
+{
+   nss internal stuff (FreeBSD 11.1)
+   Memcheck:Addr8
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   fun:PR_LoadLibraryWithFlags
+   obj:/usr/local/lib/nss/libnssutil3.so
+   fun:PORT_LoadLibraryFromOrigin
+   obj:/usr/local/lib/nss/libnss3.so
+   fun:PR_CallOnce
+   obj:/usr/local/lib/nss/libnss3.so
+   fun:SECMOD_LoadModule
+   obj:/usr/local/lib/nss/libnss3.so
+}
+{
+   nss internal stuff (FreeBSD 11.1)
+   Memcheck:Addr8
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/libexec/ld-elf.so.1
+   obj:/usr/local/lib/libcrypto.so.10
+   fun:DSO_load
+   fun:DSO_dsobyaddr
+   obj:/usr/local/lib/libcrypto.so.10
+   fun:pthread_once
+   fun:CRYPTO_THREAD_run_once
+   fun:OPENSSL_init_crypto
+   fun:opensslcrypto_load_lib
+}

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,26 @@ if test "x$dllibs" != "xnone required"; then
 	AC_SUBST([dl_LIBS], [$dllibs])
 fi
 
+# OS detection
+
+AC_MSG_CHECKING([for os in ${host_os}])
+case "$host_os" in
+	*linux*)
+		AC_DEFINE_UNQUOTED([KNET_LINUX], [1], [Compiling for Linux platform])
+		AC_MSG_RESULT([Linux])
+		;;
+	*bsd*)
+		AC_DEFINE_UNQUOTED([KNET_BSD], [1], [Compiling for BSD platform])
+		AC_MSG_RESULT([BSD])
+		if test "x$enable_libtap" = xyes; then
+			AC_MSG_ERROR([libtap is not currently supported on BSD platforms])
+		fi
+		;;
+	*)
+		AC_MSG_ERROR([Unsupported OS? hmmmm])
+		;;
+esac
+
 # crypto libraries checks
 if test "x$enable_crypto_nss" = xyes; then
 	PKG_CHECK_MODULES([nss],[nss])

--- a/libknet/compress_zlib.c
+++ b/libknet/compress_zlib.c
@@ -20,7 +20,12 @@
 #include "logging.h"
 #include "common.h"
 
+#ifdef KNET_LINUX
 #define LIBZ_1 "libz.so.1"
+#endif
+#ifdef KNET_BSD
+#define LIBZ_1 "libz.so"
+#endif
 
 /*
  * global vars for dlopen

--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -34,7 +34,12 @@
  * Fedora packages it one way, Debian another
  * and it changes by version
  */
+#ifdef KNET_LINUX
 #define LIBOPENSSL "libcrypto.so"
+#endif
+#ifdef KNET_BSD
+#define LIBOPENSSL "libcrypto.so.10"
+#endif
 
 /*
  * global vars for dlopen

--- a/libknet/tests/api-test-coverage
+++ b/libknet/tests/api-test-coverage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 srcdir="$1"/libknet/tests
 builddir="$2"/libknet/tests

--- a/libknet/tests/api_knet_link_get_ping_timers.c
+++ b/libknet/tests/api_knet_link_get_ping_timers.c
@@ -167,7 +167,7 @@ static void test(void)
 		exit(FAIL);
 	}
 
-	printf("DEFAULT: int: %ld timeout: %ld prec: %u\n", interval, timeout, precision);
+	printf("DEFAULT: int: %ld timeout: %ld prec: %u\n", (long int)interval, (long int)timeout, precision);
 
 	if ((interval != KNET_LINK_DEFAULT_PING_INTERVAL) ||
 	    (timeout != KNET_LINK_DEFAULT_PING_TIMEOUT) ||


### PR DESCRIPTION
I don't particularly enjoy the use of host detection in configure.ac,
but there is no easier way to set the library names for dlopen without
some complex and fragile scripts.

BSD valgrind + nss complains about some non-initialized memory access.
being internal to nss we can ignore it.

on BSD i386 size of time_t is int32_t vs all other platforms where is int64_t.
BSD doesn't appear to be offerign any PRIx conversion and since it's contained
within the testsuite only (for printf purposes), cast and get away with it.

add check to avoid building libtap on BSD for now.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>