### PR TITLE
doc: Add @copyright so that doxygen includes it in man pages

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -17,6 +17,7 @@
 /**
  * @file libknet.h
  * @brief kronosnet API include file
+ * @copyright Copyright (C) 2010-2015 Red Hat, Inc.  All rights reserved.
  *
  * Kronosnet is an advanced VPN system for High Availability applications.
  */


### PR DESCRIPTION
Adds the missing COPYRIGHT section to the man pages

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>