### PR TITLE
Generate dependency information for plugin libraries

### DIFF
--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -97,6 +97,14 @@ libknet_la_LDFLAGS	= -Wl,--version-script=$(srcdir)/$(SYMFILE) \
 
 libknet_la_LIBADD	= $(dl_LIBS) $(pthread_LIBS) $(rt_LIBS) $(m_LIBS)
 
+noinst_PROGRAMS		= crypto_canary compress_canary
+crypto_canary_SOURCES	= crypto_canary.c
+crypto_canary_CFLAGS	= $(nss_CFLAGS) $(openssl_CFLAGS)
+crypto_canary_LDADD	= $(nss_LIBS)   $(openssl_LIBS)
+compress_canary_SOURCES	= compress_canary.c
+compress_canary_CFLAGS	= $(zlib_CFLAGS) $(liblz4_CFLAGS) $(lzo2_CFLAGS) $(liblzma_CFLAGS) $(bzip2_CFLAGS)
+compress_canary_LDADD	= $(zlib_LIBS)   $(liblz4_LIBS)   $(lzo2_LIBS)   $(liblzma_LIBS)   $(bzip2_LIBS)
+
 dist_man_MANS		= man
 
 update-man-pages: doxyfile.stamp

--- a/libknet/compress_canary.c
+++ b/libknet/compress_canary.c
@@ -1,0 +1,32 @@
+/* Transform the binary into dependencies like:
+ * dpkg-shlibdeps -pcompress -dSuggests -xlibc6 -elibknet/compress_canary
+ */
+
+#include "config.h"
+
+char BZ2_bzBuffToBuffCompress(void);
+char LZ4_compress_HC(void);
+char lzma_easy_buffer_encode(void);
+char lzo1x_1_compress(void);
+char compress2(void);
+
+int main (void)
+{
+  return
+#ifdef BUILDCOMPBZIP2
+    BZ2_bzBuffToBuffCompress() +
+#endif
+#ifdef BUILDCOMPLZ4
+    LZ4_compress_HC() +
+#endif
+#ifdef BUILDCOMPLZMA
+    lzma_easy_buffer_encode() +
+#endif
+#ifdef BUILDCOMPLZO2
+    lzo1x_1_compress() +
+#endif
+#ifdef BUILDCOMPZLIB
+    compress2() +
+#endif
+    0;
+}

--- a/libknet/crypto_canary.c
+++ b/libknet/crypto_canary.c
@@ -1,0 +1,20 @@
+/* Transform the binary into dependencies like:
+ * dpkg-shlibdeps -pcrypto -dRecommends -xlibc6 -elibknet/crypto_canary -O | sed 's/,/ |/g' >>debian/substvars
+ */
+
+#include "config.h"
+
+char NSS_NoDB_Init(void);
+char EVP_EncryptInit_ex(void);
+
+int main (void)
+{
+  return
+#ifdef BUILDCRYPTONSS
+    NSS_NoDB_Init() +
+#endif
+#ifdef BUILDCRYPTOOPENSSL
+    EVP_EncryptInit_ex() +
+#endif
+    0;
+}


### PR DESCRIPTION
Here's my take on the plugin dependency generation.
The symbols used by the canaries are arbitrary here, but they could be chosen wisely (or just used altogether) to generate proper version constraints (if some of them appeared in later library versions). If there was a way to easily enumerate all used symbols, that would be perfect.
The solist created by the kronosnet/debian-fixes branch is somewhat tricky to use:
<pre>
$ dpkg -S $(cat libknet/solist) | cut -d: -f1 | sort -u
firefox-esr
libbz2-1.0
liblz4-1
liblzma5
liblzo2-2
libnss3
libssl1.0.2
libssl1.1
libssl-dev
pristine-tar
zlib1g
</pre>
This naive approach finds unrelated packages and does not separate libssl1.0 and 1.1. I find the grep step fragile, too. On the positive side it's simpler and does not require maintaining a symbol list, which is a weak point of my solution.
Making the crypto dependencies alternative is problematic both ways, because NSS is used together with NSPR. Leaving out the latter is a good approximation for now, because it's pulled in anyway, but not a perfect solution.
What do you think?