### PR TITLE
stats: Make the crypt_packet stats balance

### DIFF
--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -1527,6 +1527,16 @@ int knet_handle_get_stats(knet_handle_t knet_h, struct knet_handle_stats *stats,
 
 	memmove(stats, &knet_h->stats, struct_size);
 
+	/*
+	 * TX crypt stats only count the data packets sent, so add in the ping/pong/pmtud figures
+	 * RX is OK as it counts them before they are sorted.
+	 */
+
+	stats->tx_crypt_packets += knet_h->stats_extra.tx_crypt_ping_packets +
+		knet_h->stats_extra.tx_crypt_pong_packets +
+		knet_h->stats_extra.tx_crypt_pmtu_packets +
+		knet_h->stats_extra.tx_crypt_pmtu_reply_packets;
+
 	/* Tell the caller our full size in case they have an old version */
 	stats->size = sizeof(struct knet_handle_stats);
 
@@ -1560,6 +1570,7 @@ int knet_handle_clear_stats(knet_handle_t knet_h, int clear_option)
 	}
 
 	memset(&knet_h->stats, 0, sizeof(struct knet_handle_stats));
+	memset(&knet_h->stats_extra, 0, sizeof(struct knet_handle_stats_extra));
 	if (clear_option == KNET_CLEARSTATS_HANDLE_AND_LINK) {
 		_link_clear_stats(knet_h);
 	}

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -137,6 +137,13 @@ struct knet_fd_trackers {
 
 #define KNET_MAX_COMPRESS_METHODS UINT8_MAX
 
+struct knet_handle_stats_extra {
+	uint64_t tx_crypt_pmtu_packets;
+	uint64_t tx_crypt_pmtu_reply_packets;
+	uint64_t tx_crypt_ping_packets;
+	uint64_t tx_crypt_pong_packets;
+};
+
 struct knet_handle {
 	knet_node_id_t host_id;
 	unsigned int enabled:1;
@@ -156,6 +163,7 @@ struct knet_handle {
 	knet_transport_t transports[KNET_MAX_TRANSPORTS+1];
 	struct knet_fd_trackers knet_transport_fd_tracker[KNET_MAX_FDS]; /* track status for each fd handled by transports */
 	struct knet_handle_stats stats;
+	struct knet_handle_stats_extra stats_extra;
 	uint32_t reconnect_int;
 	knet_node_id_t host_ids[KNET_MAX_HOST];
 	size_t host_ids_entries;

--- a/libknet/tests/crypto_bench.c
+++ b/libknet/tests/crypto_bench.c
@@ -32,6 +32,7 @@ static void test(void)
 	knet_handle_t knet_h;
 	int logfd;
 	struct knet_handle_crypto_cfg knet_handle_crypto_cfg;
+	struct knet_handle_stats knet_stats;
 	char *buf1, *buf2, *buf3;
 	const char *input = "Encrypt me!\x0";
 	ssize_t input_len = strlen(input) + 1;
@@ -232,6 +233,8 @@ static void test(void)
 	timespec_diff(clock_start, clock_end, &time_diff);
 
 	printf("Execution of 1000000 loops (iov_in multi api): %llu/ns\n", time_diff);
+
+	knet_handle_get_stats(knet_h, &knet_stats, sizeof(knet_stats));
 
 	printf("Shutdown crypto\n");
 

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -80,6 +80,7 @@ static void _handle_check_each(knet_handle_t knet_h, struct knet_host *dst_host,
 			}
 
 			outbuf = knet_h->pingbuf_crypt;
+			knet_h->stats_extra.tx_crypt_ping_packets++;
 		}
 
 retry:

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -132,6 +132,7 @@ restart:
 		}
 
 		outbuf = knet_h->pmtudbuf_crypt;
+		knet_h->stats_extra.tx_crypt_pmtu_packets++;
 
 	} else {
 

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -563,6 +563,7 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 				break;
 			}
 			outbuf = knet_h->recv_from_links_buf_crypt;
+			knet_h->stats_extra.tx_crypt_pong_packets++;
 		}
 
 retry_pong:
@@ -650,6 +651,7 @@ retry_pong:
 				break;
 			}
 			outbuf = knet_h->recv_from_links_buf_crypt;
+			knet_h->stats_extra.tx_crypt_pmtu_reply_packets++;
 		}
 
 retry_pmtud:


### PR DESCRIPTION
The tx_crypt stats only included data packets whereas the rx_crypt
stats included everything, because the TX was done in different places
and the RX in just the one.

I've added a 'stats_extra' structure so that the other threads can
update their own stats without extra locking, the get_stats call adds
them in as necessary.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>