### PR TITLE
[build] workaround memory alignment bug in nss in combination with va…

### DIFF
--- a/build-aux/check.mk
+++ b/build-aux/check.mk
@@ -8,7 +8,7 @@
 
 VALGRIND = $(VALGRIND_EXEC) -q --error-exitcode=127 --gen-suppressions=all
 
-MEMCHECK = $(VALGRIND) --track-fds=yes --leak-check=full --suppressions=$(abs_top_srcdir)/build-aux/knet_valgrind_memcheck.supp
+MEMCHECK = $(VALGRIND) --track-fds=yes --leak-check=full --alignment=16 --suppressions=$(abs_top_srcdir)/build-aux/knet_valgrind_memcheck.supp
 HELGRIND = $(VALGRIND) --tool=helgrind --suppressions=$(abs_top_srcdir)/build-aux/knet_valgrind_helgrind.supp
 
 check-memcheck: $(check_PROGRAMS)


### PR DESCRIPTION
…lgrind on Linux/i386

Over the past few weeks, we noticed CI failing on i386 when running make check-memcheck
(test suite executed with valgring). Those failures were not consistent and sometime random.

After some heavy debugging it turns out that those failures are a combination of libnss3
internal memory allocator bug and valgrind internal memory allocator.

Current libnss3 memory allocator expects a 16 bytes memory aligned
buffer and in the event the memory is not aligned, it would round it.
The issue is that, in performing this rounding, nss does not track properly the
original address of the memory, and the equivalent of subsequent free of this buffer
would fail, leaking memory and potentially accessing memory not allocated or corrpting
memory.

The nss bug is already fixed upstream by commit: changeset:   13557:52e38f913220

Valgrind on Linux/i386 memory allocator can return memory that is not aligned to the 16 bytes,
contrary to what malloc/glibc does. Valgrind was returning (somehow randomly) a non aligned
buffer to nss triggering the nss bug and the leak.

By forcing valgrind to use aligned memory, nss bug does not trigger and there is no memory leak
during the execution of the test suite.

The memory leak never triggered when running knet in normal conditions.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>