### PR TITLE
build: determine the plugin SONAMEs automatically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,10 +201,23 @@ case "$host_os" in
 		;;
 esac
 
+AC_DEFUN([KNET_PKG_SONAME],[
+AC_MSG_CHECKING([for soname of $1])
+$CC -shared -nostdlib -o dummy.so -Wl,--no-as-needed $$1_LIBS
+# Choosing the first SONAME is a best guess here:
+knet_pkg_soname=`$OBJDUMP -p dummy.so | $SED -n '/^Dynamic Section:$/,/^[^ ]/{s/ *NEEDED *//p;}' | head -n1`
+rm dummy.so
+AC_DEFINE_UNQUOTED([$2],["$knet_pkg_soname"],[SONAME of the $1 library])
+AS_IF([test "x$knet_pkg_soname" = x],
+	[AC_MSG_FAILURE([failed to extract SONAME])],
+	[AC_MSG_RESULT([$knet_pkg_soname])])
+])
+
 # crypto libraries checks
 if test "x$enable_crypto_nss" = xyes; then
 	PKG_CHECK_MODULES([nss],[nss])
 	AC_DEFINE_UNQUOTED([BUILDCRYPTONSS], [1], [Enable nss crypto])
+	KNET_PKG_SONAME([nss],[LIBNSS3])
 fi
 
 if test "x$enable_crypto_openssl" = xyes; then
@@ -213,16 +226,19 @@ if test "x$enable_crypto_openssl" = xyes; then
 			  [PKG_CHECK_MODULES([openssl],[libcrypto >= 1.1],
 					     [AC_DEFINE_UNQUOTED([BUILDCRYPTOOPENSSL11], [1], [openssl 1.1 crypto])])])
 	AC_DEFINE_UNQUOTED([BUILDCRYPTOOPENSSL], [1], [Enable openssl crypto])
+	KNET_PKG_SONAME([openssl],[LIBOPENSSL])
 fi
 
 # compress libraries checks
 if test "x$enable_compress_zlib" = xyes; then
 	PKG_CHECK_MODULES([zlib], [zlib])
 	AC_DEFINE_UNQUOTED([BUILDCOMPZLIB], [1], [Enable zlib compression])
+	KNET_PKG_SONAME([zlib],[LIBZ_1])
 fi
 if test "x$enable_compress_lz4" = xyes; then
 	PKG_CHECK_MODULES([liblz4], [liblz4])
 	AC_DEFINE_UNQUOTED([BUILDCOMPLZ4], [1], [Enable lz4 compress])
+	KNET_PKG_SONAME([liblz4],[LIBLZ4_1])
 fi
 if test "x$enable_compress_lzo2" = xyes; then
 	PKG_CHECK_MODULES([lzo2], [lzo2],,
@@ -231,10 +247,12 @@ if test "x$enable_compress_lzo2" = xyes; then
 				[AC_SUBST([lzo2_LIBS], [-llzo2])])],
 				[AC_MSG_ERROR(["missing required lzo/lzo1x.h header"])])])
 	AC_DEFINE_UNQUOTED([BUILDCOMPLZO2], [1], [Enable lzo2 compress])
+	KNET_PKG_SONAME([lzo2],[LIBLZO2_2])
 fi
 if test "x$enable_compress_lzma" = xyes; then
 	PKG_CHECK_MODULES([liblzma], [liblzma])
 	AC_DEFINE_UNQUOTED([BUILDCOMPLZMA], [1], [Enable lzma compress])
+	KNET_PKG_SONAME([liblzma],[LIBLZMA_5])
 fi
 if test "x$enable_compress_bzip2" = xyes; then
 	PKG_CHECK_MODULES([bzip2], [bzip2],,
@@ -243,6 +261,7 @@ if test "x$enable_compress_bzip2" = xyes; then
 				[AC_SUBST([bzip2_LIBS], [-lbz2])])],
 				[AC_MSG_ERROR(["missing required bzlib.h"])])])
 	AC_DEFINE_UNQUOTED([BUILDCOMPBZIP2], [1], [Enable bzip2 compress])
+	KNET_PKG_SONAME([bzip2],[LIBBZ2_1])
 fi
 
 # Checks for header files.

--- a/libknet/compress_bzip2.c
+++ b/libknet/compress_bzip2.c
@@ -20,8 +20,6 @@
 #include "logging.h"
 #include "common.h"
 
-#define LIBBZ2_1 "libbz2.so.1"
-
 /*
  * global vars for dlopen
  */

--- a/libknet/compress_lz4.c
+++ b/libknet/compress_lz4.c
@@ -20,8 +20,6 @@
 #include "logging.h"
 #include "common.h"
 
-#define LIBLZ4_1 "liblz4.so.1"
-
 /*
  * global vars for dlopen
  */

--- a/libknet/compress_lzma.c
+++ b/libknet/compress_lzma.c
@@ -20,8 +20,6 @@
 #include "logging.h"
 #include "common.h"
 
-#define LIBLZMA_5 "liblzma.so.5"
-
 /*
  * global vars for dlopen
  */

--- a/libknet/compress_lzo2.c
+++ b/libknet/compress_lzo2.c
@@ -20,8 +20,6 @@
 #include "logging.h"
 #include "common.h"
 
-#define LIBLZO2_2 "liblzo2.so.2"
-
 /*
  * global vars for dlopen
  */

--- a/libknet/compress_zlib.c
+++ b/libknet/compress_zlib.c
@@ -20,13 +20,6 @@
 #include "logging.h"
 #include "common.h"
 
-#ifdef KNET_LINUX
-#define LIBZ_1 "libz.so.1"
-#endif
-#ifdef KNET_BSD
-#define LIBZ_1 "libz.so"
-#endif
-
 /*
  * global vars for dlopen
  */

--- a/libknet/crypto_nss.c
+++ b/libknet/crypto_nss.c
@@ -28,8 +28,6 @@
 #include "crypto_nss.h"
 #include "logging.h"
 
-#define LIBNSS3 "libnss3.so"
-
 /*
  * global vars for dlopen
  */

--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -30,18 +30,6 @@
 #define SSLERR_BUF_SIZE 512
 
 /*
- * make this more generic.
- * Fedora packages it one way, Debian another
- * and it changes by version
- */
-#ifdef KNET_LINUX
-#define LIBOPENSSL "libcrypto.so"
-#endif
-#ifdef KNET_BSD
-#define LIBOPENSSL "libcrypto.so.10"
-#endif
-
-/*
  * global vars for dlopen
  */
 static void *openssl_lib;


### PR DESCRIPTION
Most importantly, this avoids dlopening libcrypto.so, which is a symlink
in the OpenSSL development packages on Linux.  Rather, we use the SONAME
of the first library added by pkg-config, which seems to work well across
the board.  The strange case is NSS, which ends up using libssl3.so on
CentOS, Fedora and RedHat, but libnss3.so on Debian, FreeBSD and Ubuntu.
The tests pass regardless, so this might be tolerable.