### PR TITLE
Enable testing without root privileges

### DIFF
--- a/libknet/tests/api_knet_get_compress_list.c
+++ b/libknet/tests/api_knet_get_compress_list.c
@@ -62,8 +62,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_get_crypto_list.c
+++ b/libknet/tests/api_knet_get_crypto_list.c
@@ -62,8 +62,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_get_transport_id_by_name.c
+++ b/libknet/tests/api_knet_get_transport_id_by_name.c
@@ -48,8 +48,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_get_transport_list.c
+++ b/libknet/tests/api_knet_get_transport_list.c
@@ -63,8 +63,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_get_transport_name_by_id.c
+++ b/libknet/tests/api_knet_get_transport_name_by_id.c
@@ -46,8 +46,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_add_datafd.c
+++ b/libknet/tests/api_knet_handle_add_datafd.c
@@ -216,8 +216,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_clear_stats.c
+++ b/libknet/tests/api_knet_handle_clear_stats.c
@@ -289,8 +289,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_compress.c
+++ b/libknet/tests/api_knet_handle_compress.c
@@ -162,8 +162,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 #ifdef BUILDCOMPZLIB

--- a/libknet/tests/api_knet_handle_crypto.c
+++ b/libknet/tests/api_knet_handle_crypto.c
@@ -259,8 +259,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 #if defined(BUILDCRYPTONSS) || defined(BUILDCRYPTOOPENSSL)

--- a/libknet/tests/api_knet_handle_enable_filter.c
+++ b/libknet/tests/api_knet_handle_enable_filter.c
@@ -150,8 +150,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_enable_pmtud_notify.c
+++ b/libknet/tests/api_knet_handle_enable_pmtud_notify.c
@@ -141,8 +141,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_enable_sock_notify.c
+++ b/libknet/tests/api_knet_handle_enable_sock_notify.c
@@ -136,8 +136,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_free.c
+++ b/libknet/tests/api_knet_handle_free.c
@@ -82,8 +82,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_get_channel.c
+++ b/libknet/tests/api_knet_handle_get_channel.c
@@ -144,8 +144,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_get_datafd.c
+++ b/libknet/tests/api_knet_handle_get_datafd.c
@@ -144,8 +144,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_get_stats.c
+++ b/libknet/tests/api_knet_handle_get_stats.c
@@ -102,8 +102,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_get_transport_reconnect_interval.c
+++ b/libknet/tests/api_knet_handle_get_transport_reconnect_interval.c
@@ -82,8 +82,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_new.c
+++ b/libknet/tests/api_knet_handle_new.c
@@ -131,8 +131,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_new_limit.c
+++ b/libknet/tests/api_knet_handle_new_limit.c
@@ -64,8 +64,6 @@ int main(int argc, char *argv[])
 		return SKIP;
 	}
 
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_pmtud_get.c
+++ b/libknet/tests/api_knet_handle_pmtud_get.c
@@ -79,8 +79,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_pmtud_getfreq.c
+++ b/libknet/tests/api_knet_handle_pmtud_getfreq.c
@@ -79,8 +79,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_pmtud_setfreq.c
+++ b/libknet/tests/api_knet_handle_pmtud_setfreq.c
@@ -90,8 +90,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_remove_datafd.c
+++ b/libknet/tests/api_knet_handle_remove_datafd.c
@@ -122,8 +122,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_set_transport_reconnect_interval.c
+++ b/libknet/tests/api_knet_handle_set_transport_reconnect_interval.c
@@ -81,8 +81,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_handle_setfwd.c
+++ b/libknet/tests/api_knet_handle_setfwd.c
@@ -101,8 +101,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_add.c
+++ b/libknet/tests/api_knet_host_add.c
@@ -106,8 +106,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_enable_status_change_notify.c
+++ b/libknet/tests/api_knet_host_enable_status_change_notify.c
@@ -144,8 +144,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_get_host_list.c
+++ b/libknet/tests/api_knet_host_get_host_list.c
@@ -140,8 +140,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_get_id_by_host_name.c
+++ b/libknet/tests/api_knet_host_get_id_by_host_name.c
@@ -112,8 +112,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_get_name_by_host_id.c
+++ b/libknet/tests/api_knet_host_get_name_by_host_id.c
@@ -101,8 +101,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_get_policy.c
+++ b/libknet/tests/api_knet_host_get_policy.c
@@ -117,8 +117,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_get_status.c
+++ b/libknet/tests/api_knet_host_get_status.c
@@ -100,8 +100,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_remove.c
+++ b/libknet/tests/api_knet_host_remove.c
@@ -159,8 +159,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_set_name.c
+++ b/libknet/tests/api_knet_host_set_name.c
@@ -171,8 +171,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_host_set_policy.c
+++ b/libknet/tests/api_knet_host_set_policy.c
@@ -107,8 +107,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_clear_config.c
+++ b/libknet/tests/api_knet_link_clear_config.c
@@ -166,8 +166,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_get_config.c
+++ b/libknet/tests/api_knet_link_get_config.c
@@ -326,8 +326,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_get_enable.c
+++ b/libknet/tests/api_knet_link_get_enable.c
@@ -193,8 +193,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_get_link_list.c
+++ b/libknet/tests/api_knet_link_get_link_list.c
@@ -170,8 +170,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_get_ping_timers.c
+++ b/libknet/tests/api_knet_link_get_ping_timers.c
@@ -188,8 +188,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_get_pong_count.c
+++ b/libknet/tests/api_knet_link_get_pong_count.c
@@ -165,8 +165,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_get_priority.c
+++ b/libknet/tests/api_knet_link_get_priority.c
@@ -165,8 +165,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_get_status.c
+++ b/libknet/tests/api_knet_link_get_status.c
@@ -149,8 +149,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_set_config.c
+++ b/libknet/tests/api_knet_link_set_config.c
@@ -265,8 +265,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_set_enable.c
+++ b/libknet/tests/api_knet_link_set_enable.c
@@ -342,8 +342,6 @@ static void test_sctp(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	printf("Testing with UDP\n");
 
 	test_udp();

--- a/libknet/tests/api_knet_link_set_ping_timers.c
+++ b/libknet/tests/api_knet_link_set_ping_timers.c
@@ -184,8 +184,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_set_pong_count.c
+++ b/libknet/tests/api_knet_link_set_pong_count.c
@@ -154,8 +154,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_link_set_priority.c
+++ b/libknet/tests/api_knet_link_set_priority.c
@@ -141,8 +141,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_log_get_loglevel.c
+++ b/libknet/tests/api_knet_log_get_loglevel.c
@@ -94,8 +94,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_log_set_loglevel.c
+++ b/libknet/tests/api_knet_log_set_loglevel.c
@@ -101,8 +101,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_recv.c
+++ b/libknet/tests/api_knet_recv.c
@@ -208,8 +208,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_send.c
+++ b/libknet/tests/api_knet_send.c
@@ -321,8 +321,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_send_compress.c
+++ b/libknet/tests/api_knet_send_compress.c
@@ -267,8 +267,6 @@ static void test(const char *model)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test("none");
 
 #ifdef BUILDCOMPZLIB

--- a/libknet/tests/api_knet_send_crypto.c
+++ b/libknet/tests/api_knet_send_crypto.c
@@ -248,8 +248,6 @@ static void test(const char *model)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 #ifdef BUILDCRYPTONSS
 	test("nss");
 #endif

--- a/libknet/tests/api_knet_send_loopback.c
+++ b/libknet/tests/api_knet_send_loopback.c
@@ -400,8 +400,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/api_knet_send_sync.c
+++ b/libknet/tests/api_knet_send_sync.c
@@ -392,8 +392,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/crypto_bench.c
+++ b/libknet/tests/crypto_bench.c
@@ -249,8 +249,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	printf("Testing with default scheduler\n");
 
 	set_scheduler(SCHED_OTHER);

--- a/libknet/tests/int_crypto.c
+++ b/libknet/tests/int_crypto.c
@@ -138,8 +138,6 @@ static void test(void)
 
 int main(int argc, char *argv[])
 {
-	need_root();
-
 	test();
 
 	return PASS;

--- a/libknet/tests/knet_bench.c
+++ b/libknet/tests/knet_bench.c
@@ -1203,8 +1203,6 @@ int main(int argc, char *argv[])
 		exit(FAIL);
 	}
 
-	need_root();
-
 	setup_knet(argc, argv);
 
 	setup_data_txrx_common();

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -182,7 +182,6 @@ int need_root(void)
 {
 	if (geteuid() != 0) {
 		printf("This test requires root privileges\n");
-		exit(SKIP);
 	}
 
 	return PASS;

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -178,15 +178,6 @@ int is_helgrind(void)
 	return 0;
 }
 
-int need_root(void)
-{
-	if (geteuid() != 0) {
-		printf("This test requires root privileges\n");
-	}
-
-	return PASS;
-}
-
 void set_scheduler(int policy)
 {
 	struct sched_param sched_param;

--- a/libknet/tests/test-common.h
+++ b/libknet/tests/test-common.h
@@ -37,8 +37,6 @@ int execute_shell(const char *command, char **error_string);
 int is_memcheck(void);
 int is_helgrind(void);
 
-int need_root(void);
-
 void set_scheduler(int policy);
 
 /*

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -69,10 +69,37 @@ int _sendmmsg(int sockfd, struct knet_mmsghdr *msgvec, unsigned int vlen, unsign
 	return ((i > 0) ? (int)i : err);
 }
 
+/* Assume neither of these constants can ever be zero */
+#ifndef SO_RCVBUFFORCE
+#define SO_RCVBUFFORCE 0
+#endif
+#ifndef SO_SNDBUFFORCE
+#define SO_SNDBUFFORCE 0
+#endif
+
+static int _configure_sockbuf (int sock, int option, int force, int target)
+{
+	int new_value;
+	socklen_t value_len = sizeof new_value;
+
+	if (setsockopt(sock, SOL_SOCKET, option, &target, sizeof target) == 0 &&
+	    getsockopt(sock, SOL_SOCKET, option, &new_value, &value_len) == 0) {
+		if (value_len == sizeof new_value && target <= new_value) {
+			return 0;
+		}
+		errno = EINVAL;
+	}
+
+	if (force) {
+		return setsockopt(sock, SOL_SOCKET, force, &target, sizeof target);
+	} else {
+		return -1;
+	}
+}
+
 int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, const char *type)
 {
 	int err = 0, savederrno = 0;
-	int value;
 
 	if (_fdset_cloexec(sock)) {
 		savederrno = errno;
@@ -90,47 +117,25 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 		goto exit_error;
 	}
 
-	value = KNET_RING_RCVBUFF;
-#ifdef SO_RCVBUFFORCE
-	if (setsockopt(sock, SOL_SOCKET, SO_RCVBUFFORCE, &value, sizeof(value)) < 0) {
+	if (_configure_sockbuf (sock, SO_RCVBUF, SO_RCVBUFFORCE, KNET_RING_RCVBUFF)) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s receive buffer: %s",
 			type, strerror(savederrno));
 		goto exit_error;
 	}
-#else
-	if (setsockopt(sock, SOL_SOCKET, SO_RCVBUF, &value, sizeof(value)) < 0) {
-		savederrno = errno;
-		err = -1;
-		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s SO_RECVBUF: %s",
-			type, strerror(savederrno));
-		goto exit_error;
-	}
-#endif
 
-	value = KNET_RING_RCVBUFF;
-#ifdef SO_SNDBUFFORCE
-	if (setsockopt(sock, SOL_SOCKET, SO_SNDBUFFORCE, &value, sizeof(value)) < 0) {
+	if (_configure_sockbuf (sock, SO_SNDBUF, SO_SNDBUFFORCE, KNET_RING_RCVBUFF)) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s send buffer: %s",
 			type, strerror(savederrno));
 		goto exit_error;
 	}
-#else
-	if (setsockopt(sock, SOL_SOCKET, SO_SNDBUF, &value, sizeof(value)) < 0) {
-		savederrno = errno;
-		err = -1;
-		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s SO_SNDBUF: %s",
-			type, strerror(savederrno));
-		goto exit_error;
-	}
-#endif
 
 #ifdef SO_PRIORITY
 	if (flags & KNET_LINK_FLAG_TRAFFICHIPRIO) {
-		value = 6; /* TC_PRIO_INTERACTIVE */
+		int value = 6; /* TC_PRIO_INTERACTIVE */
 		if (setsockopt(sock, SOL_SOCKET, SO_PRIORITY, &value, sizeof(value)) < 0) {
 			savederrno = errno;
 			err = -1;
@@ -142,7 +147,7 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 #endif
 #if defined(IP_TOS) && defined(IPTOS_LOWDELAY)
 	if (flags & KNET_LINK_FLAG_TRAFFICHIPRIO) {
-		value = IPTOS_LOWDELAY;
+		int value = IPTOS_LOWDELAY;
 		if (setsockopt(sock, IPPROTO_IP, IP_TOS, &value, sizeof(value)) < 0) {
 			savederrno = errno;
 			err = -1;


### PR DESCRIPTION
If /proc/sys/net/core/[rw]mem_max are set to at least 8388608
(KNET_RING_RCVBUFF), the tests don't need root privileges.

This is admittedly sketchy, for example I left in the message stating the need for root privileges.
Maybe the error reporting could be made more detailed at well.

By the way: are large socket buffers critical for knet? Would it make any sense to run/test without them?