### PR TITLE
Skip tests if socket buffers are inadequate

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -107,6 +107,9 @@ typedef struct knet_handle *knet_handle_t;
  * @return
  * on success, a new knet_handle_t is returned.
  * on failure, NULL is returned and errno is set.
+ * knet-specific errno values:
+ *   ENAMETOOLONG - socket buffers couldn't be set big enough
+ *   ERANGE       - buffer size readback returned unexpected type
  */
 
 knet_handle_t knet_handle_new(knet_node_id_t host_id,

--- a/libknet/tests/api_knet_handle_add_datafd.c
+++ b/libknet/tests/api_knet_handle_add_datafd.c
@@ -49,14 +49,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_add_datafd with no datafd\n");
 

--- a/libknet/tests/api_knet_handle_clear_stats.c
+++ b/libknet/tests/api_knet_handle_clear_stats.c
@@ -63,14 +63,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_send with valid data\n");
 

--- a/libknet/tests/api_knet_handle_compress.c
+++ b/libknet/tests/api_knet_handle_compress.c
@@ -36,14 +36,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_handle_crypto.c
+++ b/libknet/tests/api_knet_handle_crypto.c
@@ -36,14 +36,7 @@ static void test(const char *model)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_handle_enable_filter.c
+++ b/libknet/tests/api_knet_handle_enable_filter.c
@@ -48,14 +48,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_enable_filter with no private_data\n");
 

--- a/libknet/tests/api_knet_handle_enable_pmtud_notify.c
+++ b/libknet/tests/api_knet_handle_enable_pmtud_notify.c
@@ -41,14 +41,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_enable_pmtud_notify with no private_data\n");
 

--- a/libknet/tests/api_knet_handle_enable_sock_notify.c
+++ b/libknet/tests/api_knet_handle_enable_sock_notify.c
@@ -45,14 +45,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_enable_sock_notify with no private_data\n");
 

--- a/libknet/tests/api_knet_handle_free.c
+++ b/libknet/tests/api_knet_handle_free.c
@@ -35,14 +35,7 @@ static void test(void)
 
 	printf("Test knet_handle_free with one host configured\n");
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	if (knet_host_add(knet_h, 1) < 0) {
 		printf("Unable to add new knet_host: %s\n", strerror(errno));

--- a/libknet/tests/api_knet_handle_get_channel.c
+++ b/libknet/tests/api_knet_handle_get_channel.c
@@ -47,14 +47,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_get_channel with invalid datafd\n");
 

--- a/libknet/tests/api_knet_handle_get_datafd.c
+++ b/libknet/tests/api_knet_handle_get_datafd.c
@@ -47,14 +47,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_get_datafd with invalid channel (< 0)\n");
 

--- a/libknet/tests/api_knet_handle_get_stats.c
+++ b/libknet/tests/api_knet_handle_get_stats.c
@@ -40,14 +40,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_get_stats with NULL structure pointer\n");
 

--- a/libknet/tests/api_knet_handle_get_transport_reconnect_interval.c
+++ b/libknet/tests/api_knet_handle_get_transport_reconnect_interval.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_get_transport_reconnect_interval with incorrect msecs\n");
 

--- a/libknet/tests/api_knet_handle_new.c
+++ b/libknet/tests/api_knet_handle_new.c
@@ -31,6 +31,11 @@ static void test(void)
 
 	knet_h = knet_handle_new(1, 0, 0);
 	if (!knet_h) {
+		if (errno == ENAMETOOLONG) {
+			printf("Socket buffers too small (at least %d bytes needed)\n",
+			       KNET_RING_RCVBUFF);
+			exit(SKIP);
+		}
 		printf("Unable to init knet_handle! err: %s\n", strerror(errno));
 		exit(FAIL);
 	}

--- a/libknet/tests/api_knet_handle_new.c
+++ b/libknet/tests/api_knet_handle_new.c
@@ -115,14 +115,7 @@ static void test(void)
 
 	printf("Test knet_handle_new hostid 1, proper log_fd, proper log level (DEBUG)\n");
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	knet_handle_free(knet_h);
 	flush_logs(logfds[0], stdout);

--- a/libknet/tests/api_knet_handle_pmtud_get.c
+++ b/libknet/tests/api_knet_handle_pmtud_get.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_handle_pmtud_getfreq.c
+++ b/libknet/tests/api_knet_handle_pmtud_getfreq.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_handle_pmtud_setfreq.c
+++ b/libknet/tests/api_knet_handle_pmtud_setfreq.c
@@ -33,14 +33,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_handle_remove_datafd.c
+++ b/libknet/tests/api_knet_handle_remove_datafd.c
@@ -47,14 +47,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_remove_datafd with no datafd\n");
 

--- a/libknet/tests/api_knet_handle_set_transport_reconnect_interval.c
+++ b/libknet/tests/api_knet_handle_set_transport_reconnect_interval.c
@@ -33,14 +33,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_handle_set_transport_reconnect_interval with incorrect msecs\n");
 

--- a/libknet/tests/api_knet_handle_setfwd.c
+++ b/libknet/tests/api_knet_handle_setfwd.c
@@ -35,14 +35,7 @@ static void test(void)
 
 	printf("Test knet_handle_setfwd with invalid param (2) \n");
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	if ((!knet_handle_setfwd(knet_h, 2)) || (errno != EINVAL)) {
 		printf("knet_handle_setfwd accepted invalid param for enabled: %s\n", strerror(errno));

--- a/libknet/tests/api_knet_host_add.c
+++ b/libknet/tests/api_knet_host_add.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_host_enable_status_change_notify.c
+++ b/libknet/tests/api_knet_host_enable_status_change_notify.c
@@ -44,14 +44,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_host_enable_status_change_notify with no private_data\n");
 

--- a/libknet/tests/api_knet_host_get_host_list.c
+++ b/libknet/tests/api_knet_host_get_host_list.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_host_get_id_by_host_name.c
+++ b/libknet/tests/api_knet_host_get_id_by_host_name.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_host_get_name_by_host_id.c
+++ b/libknet/tests/api_knet_host_get_name_by_host_id.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_host_get_policy.c
+++ b/libknet/tests/api_knet_host_get_policy.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_host_get_status.c
+++ b/libknet/tests/api_knet_host_get_status.c
@@ -37,14 +37,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_host_get_status with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_host_remove.c
+++ b/libknet/tests/api_knet_host_remove.c
@@ -36,14 +36,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_host_set_name.c
+++ b/libknet/tests/api_knet_host_set_name.c
@@ -34,14 +34,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_host_set_policy.c
+++ b/libknet/tests/api_knet_host_set_policy.c
@@ -33,14 +33,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_link_clear_config.c
+++ b/libknet/tests/api_knet_link_clear_config.c
@@ -46,14 +46,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_clear_config with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_get_config.c
+++ b/libknet/tests/api_knet_link_get_config.c
@@ -51,14 +51,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_get_config with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_get_enable.c
+++ b/libknet/tests/api_knet_link_get_enable.c
@@ -47,14 +47,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_get_enable with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_get_link_list.c
+++ b/libknet/tests/api_knet_link_get_link_list.c
@@ -50,14 +50,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_get_link_list with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_get_ping_timers.c
+++ b/libknet/tests/api_knet_link_get_ping_timers.c
@@ -48,14 +48,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_get_ping_timers with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_get_pong_count.c
+++ b/libknet/tests/api_knet_link_get_pong_count.c
@@ -47,14 +47,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_get_pong_count with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_get_priority.c
+++ b/libknet/tests/api_knet_link_get_priority.c
@@ -47,14 +47,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_get_priority with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_get_status.c
+++ b/libknet/tests/api_knet_link_get_status.c
@@ -49,14 +49,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_get_status with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_set_config.c
+++ b/libknet/tests/api_knet_link_set_config.c
@@ -53,14 +53,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_set_config with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_set_enable.c
+++ b/libknet/tests/api_knet_link_set_enable.c
@@ -46,14 +46,7 @@ static void test_udp(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_set_enable with unconfigured host_id\n");
 
@@ -204,14 +197,7 @@ static void test_sctp(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_set_enable with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_set_ping_timers.c
+++ b/libknet/tests/api_knet_link_set_ping_timers.c
@@ -46,14 +46,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_set_ping_timers with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_set_pong_count.c
+++ b/libknet/tests/api_knet_link_set_pong_count.c
@@ -46,14 +46,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_set_pong_count with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_link_set_priority.c
+++ b/libknet/tests/api_knet_link_set_priority.c
@@ -46,14 +46,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_link_set_priority with unconfigured host_id\n");
 

--- a/libknet/tests/api_knet_log_get_loglevel.c
+++ b/libknet/tests/api_knet_log_get_loglevel.c
@@ -38,14 +38,7 @@ static void test(void)
 
 	printf("Test knet_log_get_loglevel incorrect subsystem\n");
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_INFO);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_INFO);
 
 	if ((!knet_log_get_loglevel(knet_h, KNET_SUB_UNKNOWN - 1, &level)) || (errno != EINVAL)) {
 		printf("knet_log_get_loglevel accepted invalid subsystem or returned incorrect error: %s\n", strerror(errno));

--- a/libknet/tests/api_knet_log_set_loglevel.c
+++ b/libknet/tests/api_knet_log_set_loglevel.c
@@ -37,14 +37,7 @@ static void test(void)
 
 	printf("Test knet_log_set_loglevel incorrect subsystem\n");
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_INFO);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_INFO);
 
 	if ((!knet_log_set_loglevel(knet_h, KNET_SUB_UNKNOWN - 1, KNET_LOG_DEBUG)) || (errno != EINVAL)) {
 		printf("knet_log_set_loglevel accepted invalid subsystem or returned incorrect error: %s\n", strerror(errno));

--- a/libknet/tests/api_knet_recv.c
+++ b/libknet/tests/api_knet_recv.c
@@ -52,14 +52,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_recv with no recv_buff\n");
 

--- a/libknet/tests/api_knet_send.c
+++ b/libknet/tests/api_knet_send.c
@@ -63,14 +63,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_send with no send_buff\n");
 

--- a/libknet/tests/api_knet_send_compress.c
+++ b/libknet/tests/api_knet_send_compress.c
@@ -58,14 +58,7 @@ static void test(const char *model)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_send_crypto.c
+++ b/libknet/tests/api_knet_send_crypto.c
@@ -58,14 +58,7 @@ static void test(const char *model)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_send_loopback.c
+++ b/libknet/tests/api_knet_send_loopback.c
@@ -72,14 +72,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	flush_logs(logfds[0], stdout);
 

--- a/libknet/tests/api_knet_send_sync.c
+++ b/libknet/tests/api_knet_send_sync.c
@@ -117,14 +117,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	knet_h = knet_handle_new(1, logfds[1], KNET_LOG_DEBUG);
-
-	if (!knet_h) {
-		printf("knet_handle_new failed: %s\n", strerror(errno));
-		flush_logs(logfds[0], stdout);
-		close_logpipes(logfds);
-		exit(FAIL);
-	}
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
 
 	printf("Test knet_send_sync with no send_buff\n");
 

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -366,10 +366,17 @@ knet_handle_t knet_handle_start(int logfds[2], uint8_t log_level)
 	if (knet_h) {
 		return knet_h;
 	} else {
+		int exit_status;
+
+		if (errno == ENAMETOOLONG) {
+			exit_status = SKIP;
+		} else {
+			exit_status = FAIL;
+		}
 		printf("knet_handle_new failed: %s\n", strerror(errno));
 		flush_logs(logfds[0], stdout);
 		close_logpipes(logfds);
-		exit(FAIL);
+		exit(exit_status);
 	}
 }
 

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -359,6 +359,20 @@ int start_logging(FILE *std)
 	return log_fds[1];
 }
 
+knet_handle_t knet_handle_start(int logfds[2], uint8_t log_level)
+{
+	knet_handle_t knet_h = knet_handle_new(1, logfds[1], log_level);
+
+	if (knet_h) {
+		return knet_h;
+	} else {
+		printf("knet_handle_new failed: %s\n", strerror(errno));
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+}
+
 int knet_handle_stop(knet_handle_t knet_h)
 {
 	int savederrno;

--- a/libknet/tests/test-common.h
+++ b/libknet/tests/test-common.h
@@ -39,6 +39,8 @@ int is_helgrind(void);
 
 void set_scheduler(int policy);
 
+knet_handle_t knet_handle_start(int logfds[2], uint8_t log_level);
+
 /*
  * consider moving this one as official API
  */

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -91,10 +91,10 @@ static int _configure_sockbuf (knet_handle_t knet_h, int sock, int option, int f
 			return 0;
 		}
 		if (!force) {
-			savederrno = ERANGE;
-			log_debug (knet_h, KNET_SUB_TRANSPORT, "Failed to set socket buffer via option %d to value %d: %s",
-				   option, target, strerror(savederrno));
-			errno = savederrno;
+			log_debug (knet_h, KNET_SUB_TRANSPORT,
+				   "Failed to set socket buffer via option %d to value %d: capped at %d",
+				   option, target, new_value);
+			errno = ENAMETOOLONG;
 			return -1;
 		}
 	}
@@ -104,7 +104,11 @@ static int _configure_sockbuf (knet_handle_t knet_h, int sock, int option, int f
 		log_debug (knet_h, KNET_SUB_TRANSPORT,
 			   "Failed to set socket buffer via force option %d: %s",
 			   force, strerror(savederrno));
-		errno = savederrno;
+		if (savederrno == EPERM) {
+			errno = ENAMETOOLONG;
+		} else {
+			errno = savederrno;
+		}
 		return -1;
 	}
 

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -116,18 +116,18 @@ static int _configure_sockbuf (knet_handle_t knet_h, int sock, int option, int f
 	}
 
 	if (!force) {
-		log_debug (knet_h, KNET_SUB_TRANSPORT,
-			   "Failed to set socket buffer via option %d to value %d: capped at %d",
-			   option, target, new_value);
+		log_err(knet_h, KNET_SUB_TRANSPORT,
+			"Failed to set socket buffer via option %d to value %d: capped at %d",
+			option, target, new_value);
 		errno = ENAMETOOLONG;
 		return -1;
 	}
 
 	if (setsockopt(sock, SOL_SOCKET, force, &target, sizeof target) < 0) {
 		savederrno = errno;
-		log_debug (knet_h, KNET_SUB_TRANSPORT,
-			   "Failed to set socket buffer via force option %d: %s",
-			   force, strerror(savederrno));
+		log_err(knet_h, KNET_SUB_TRANSPORT,
+			"Failed to set socket buffer via force option %d: %s",
+			force, strerror(savederrno));
 		if (savederrno == EPERM) {
 			errno = ENAMETOOLONG;
 		} else {

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -79,7 +79,7 @@ int _sendmmsg(int sockfd, struct knet_mmsghdr *msgvec, unsigned int vlen, unsign
 #define SO_SNDBUFFORCE 0
 #endif
 
-static int _configure_sockbuf (knet_handle_t knet_h, int sock, int option, int force, int target)
+static int _configure_sockbuf(knet_handle_t knet_h, int sock, int option, int force, int target)
 {
 	int savederrno = 0;
 	int new_value;
@@ -87,26 +87,26 @@ static int _configure_sockbuf (knet_handle_t knet_h, int sock, int option, int f
 
 	if (setsockopt(sock, SOL_SOCKET, option, &target, sizeof target) != 0) {
 		savederrno = errno;
-		log_err (knet_h, KNET_SUB_TRANSPORT,
-			 "Error setting socket buffer via option %d to value %d: %s\n",
-			 option, target, strerror(savederrno));
+		log_err(knet_h, KNET_SUB_TRANSPORT,
+			"Error setting socket buffer via option %d to value %d: %s\n",
+			option, target, strerror(savederrno));
 		errno = savederrno;
 		return -1;
 	}
 
 	if (getsockopt(sock, SOL_SOCKET, option, &new_value, &value_len) != 0) {
 		savederrno = errno;
-		log_err (knet_h, KNET_SUB_TRANSPORT,
-			 "Error getting socket buffer via option %d: %s\n",
-			 option, strerror(savederrno));
+		log_err(knet_h, KNET_SUB_TRANSPORT,
+			"Error getting socket buffer via option %d: %s\n",
+			option, strerror(savederrno));
 		errno = savederrno;
 		return -1;
 	}
 
 	if (value_len != sizeof new_value) {
-		log_err (knet_h, KNET_SUB_TRANSPORT,
-			 "Socket option %d returned unexpected size %u\n",
-			 option, value_len);
+		log_err(knet_h, KNET_SUB_TRANSPORT,
+			"Socket option %d returned unexpected size %u\n",
+			option, value_len);
 		errno = ERANGE;
 		return -1;
 	}
@@ -160,7 +160,7 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 		goto exit_error;
 	}
 
-	if (_configure_sockbuf (knet_h, sock, SO_RCVBUF, SO_RCVBUFFORCE, KNET_RING_RCVBUFF)) {
+	if (_configure_sockbuf(knet_h, sock, SO_RCVBUF, SO_RCVBUFFORCE, KNET_RING_RCVBUFF)) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s receive buffer: %s",
@@ -168,7 +168,7 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 		goto exit_error;
 	}
 
-	if (_configure_sockbuf (knet_h, sock, SO_SNDBUF, SO_SNDBUFFORCE, KNET_RING_RCVBUFF)) {
+	if (_configure_sockbuf(knet_h, sock, SO_SNDBUF, SO_SNDBUFFORCE, KNET_RING_RCVBUFF)) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s send buffer: %s",


### PR DESCRIPTION
What do you think about this one instead of #97?
It depends on `ERANGE` having a fixed semantics from `knet_handle_new()`.