### PR TITLE
[PMTUd] fix multiple issues and stability problems

### DIFF
--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -110,6 +110,13 @@ static int _init_locks(knet_handle_t knet_h)
 		goto exit_fail;
 	}
 
+	savederrno = pthread_mutex_init(&knet_h->backoff_mutex, NULL);
+	if (savederrno) {
+		log_err(knet_h, KNET_SUB_HANDLE, "Unable to initialize pong timeout backoff mutex: %s",
+			strerror(savederrno));
+		goto exit_fail;
+	}
+
 	savederrno = pthread_mutex_init(&knet_h->tx_seq_num_mutex, NULL);
 	if (savederrno) {
 		log_err(knet_h, KNET_SUB_HANDLE, "Unable to initialize tx_seq_num_mutex mutex: %s",
@@ -132,6 +139,7 @@ static void _destroy_locks(knet_handle_t knet_h)
 	pthread_cond_destroy(&knet_h->pmtud_cond);
 	pthread_mutex_destroy(&knet_h->hb_mutex);
 	pthread_mutex_destroy(&knet_h->tx_mutex);
+	pthread_mutex_destroy(&knet_h->backoff_mutex);
 	pthread_mutex_destroy(&knet_h->tx_seq_num_mutex);
 }
 

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -185,6 +185,7 @@ struct knet_handle {
 	pthread_cond_t pmtud_cond;		/* conditional for above */
 	pthread_mutex_t tx_mutex;		/* used to protect knet_send_sync and TX thread */
 	pthread_mutex_t hb_mutex;		/* used to protect heartbeat thread and seq_num broadcasting */
+	pthread_mutex_t backoff_mutex;		/* used to protect dst_link->pong_timeout_adj */
 	struct crypto_instance *crypto_instance;
 	size_t sec_header_size;
 	size_t sec_block_size;


### PR DESCRIPTION
- resolve locking issue with thread_heartbeat that was causing
  spurious up/down link event.
  In the event of a PMTUd run taking too long, the heartbeat
  thread could hang for much longer than ping_timeout.
  Use backoff_mutex to sync between threads instead of the global lock.

- pause the DATA tx thread when sending any PMTUd related packets.
  Similar method as knet_send_sync, using the tx_mutex, allows a much
  more stable communication between nodes without any visible performance
  hit.

- calculate higher timeouts when using crypto to improve stability

- fix an odd race condition with the kernel where, during a single PMTUd run,
  the same packet size was marked both BAD and GOOD (via EMSGSIZE) by the
  kernel. That situation would cause our PMTUd to run away and calculate
  bad values.

- add a minor usleep between sending PMTUd packets to give time to the
  kernel to make its own mind about the link PMTU. This is based on average
  latency.

- since PMTUd can take several seconds before completion, use the "end time"
  to record the last run vs the start time.

- fix a major issue in sending PMTUd reply where an errno was not being
  passed down the link layer and would cause the RX thread to block forever.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>