### PR TITLE
build: work around broken pkg-config file in lzo2 version 2.10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,9 @@ AC_ARG_ENABLE([compress-all],
 KNET_OPTION_DEFINES([zlib],[compress],[PKG_CHECK_MODULES([zlib], [zlib])])
 KNET_OPTION_DEFINES([lz4],[compress],[PKG_CHECK_MODULES([liblz4], [liblz4])])
 KNET_OPTION_DEFINES([lzo2],[compress],[
-	PKG_CHECK_MODULES([lzo2], [lzo2],,
+	PKG_CHECK_MODULES([lzo2], [lzo2],
+		[# work around broken pkg-config file in v2.10
+		 AC_SUBST([lzo2_CFLAGS],[`echo $lzo2_CFLAGS | sed 's,/lzo *, ,'`])],
 		[AC_CHECK_HEADERS([lzo/lzo1x.h],
 			[AC_CHECK_LIB([lzo2], [lzo1x_decompress_safe],
 				[AC_SUBST([lzo2_LIBS], [-llzo2])])],
@@ -211,9 +213,6 @@ case "$host_os" in
 		AC_MSG_ERROR([Unsupported OS? hmmmm])
 		;;
 esac
-
-AM_CONDITIONAL([KNET_LINUX], [echo $host_os | grep -q linux])
-AM_CONDITIONAL([KNET_BSD], [echo $host_os | grep -q bsd])
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h])

--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -113,12 +113,7 @@ endif
 if BUILD_COMPRESS_LZO2
 pkglib_LTLIBRARIES	+= compress_lzo2.la
 compress_lzo2_la_LDFLAGS = -module -avoid-version
-if KNET_LINUX
 compress_lzo2_la_CFLAGS	= $(lzo2_CFLAGS)
-endif
-if KNET_BSD
-compress_lzo2_la_CFLAGS = $(lzo2_CFLAGS) -I/usr/local/include
-endif
 compress_lzo2_la_LIBADD	= $(lzo2_LIBS)
 endif
 


### PR DESCRIPTION
In principle this isn't specific to BSD, though 2.10 is only packaged
for BSDs at the moment.

Signed-off-by: Ferenc Wágner <wferi@debian.org>