### PR TITLE
Add some missing error propagation

### DIFF
--- a/libknet/crypto.c
+++ b/libknet/crypto.c
@@ -141,7 +141,7 @@ int crypto_init(
 	 */
 	knet_h->crypto_instance->model = model;
 	if (crypto_modules_cmds[knet_h->crypto_instance->model].ops->init(knet_h, knet_handle_crypto_cfg)) {
-		savederrno = EPIPE;
+		savederrno = errno;
 		goto out_err;
 	}
 

--- a/libknet/crypto.c
+++ b/libknet/crypto.c
@@ -104,6 +104,7 @@ int crypto_init(
 	if (!crypto_modules_cmds[model].loaded) {
 		crypto_modules_cmds[model].ops = load_module (knet_h, "crypto", crypto_modules_cmds[model].model_name);
 		if (!crypto_modules_cmds[model].ops) {
+			savederrno = errno;
 			log_err(knet_h, KNET_SUB_CRYPTO, "Unable to load %s lib", crypto_modules_cmds[model].model_name);
 			goto out_err;
 		}
@@ -112,7 +113,7 @@ int crypto_init(
 				"ABI mismatch loading module %s. knet ver: %d, module ver: %d",
 				crypto_modules_cmds[model].model_name, KNET_CRYPTO_MODEL_ABI,
 				crypto_modules_cmds[model].ops->abi_ver);
-			errno = EINVAL;
+			savederrno = EINVAL;
 			goto out_err;
 		}
 		crypto_modules_cmds[model].loaded = 1;
@@ -129,6 +130,7 @@ int crypto_init(
 	if (!knet_h->crypto_instance) {
 		log_err(knet_h, KNET_SUB_CRYPTO, "Unable to allocate memory for crypto instance");
 		pthread_rwlock_unlock(&shlib_rwlock);
+		savederrno = ENOMEM;
 		goto out_err;
 	}
 
@@ -138,8 +140,10 @@ int crypto_init(
 	 * crypto_modules_cmds.ops->fini is not invoked on error.
 	 */
 	knet_h->crypto_instance->model = model;
-	if (crypto_modules_cmds[knet_h->crypto_instance->model].ops->init(knet_h, knet_handle_crypto_cfg))
+	if (crypto_modules_cmds[knet_h->crypto_instance->model].ops->init(knet_h, knet_handle_crypto_cfg)) {
+		savederrno = EPIPE;
 		goto out_err;
+	}
 
 	log_debug(knet_h, KNET_SUB_CRYPTO, "security network overhead: %zu", knet_h->sec_header_size);
 	pthread_rwlock_unlock(&shlib_rwlock);
@@ -152,6 +156,7 @@ out_err:
 	}
 
 	pthread_rwlock_unlock(&shlib_rwlock);
+	errno = savederrno;
 	return -1;
 }
 

--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -577,12 +577,9 @@ static int opensslcrypto_init(
 	}
 
 	if (opensslcrypto_instance->crypto_cipher_type) {
-		int block_size;
+		size_t block_size;
 
 		block_size = EVP_CIPHER_block_size(opensslcrypto_instance->crypto_cipher_type);
-		if (block_size < 0) {
-			goto out_err;
-		}
 
 		knet_h->sec_header_size += (block_size * 2);
 		knet_h->sec_header_size += SALT_SIZE;

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -1341,6 +1341,7 @@ int knet_handle_crypto(knet_handle_t knet_h, struct knet_handle_crypto_cfg *knet
 
 	if (err) {
 		err = -2;
+		savederrno = errno;
 	}
 
 exit_unlock:


### PR DESCRIPTION
This replaces
~~~
Test knet_send with nss and valid data
knet_handle_crypto failed with correct config: Success
knet logs: [ERROR] common: unable to dlopen crypto_nss.so: crypto_nss.so: cannot open shared object file: No such file or directory
knet logs: [ERROR] crypto: Unable to load nss lib
~~~
with
~~~
Test knet_send with nss and valid data
knet_handle_crypto failed with correct config: Resource temporarily unavailable
knet logs: [ERROR] common: unable to dlopen crypto_nss.so: crypto_nss.so: cannot open shared object file: No such file or directory
knet logs: [ERROR] crypto: Unable to load nss lib
~~~
The `EAGAIN` above is somewhat surprising, but my `EPIPE` might not be the best choice either...
What do you think?