### PR TITLE
tests: check for exported symbols in the data section as well

### DIFF
--- a/libknet/tests/api-test-coverage
+++ b/libknet/tests/api-test-coverage
@@ -12,7 +12,10 @@ builddir="$2"/libknet/tests
 
 headerapicalls="$(grep knet_ "$srcdir"/../libknet.h | grep -v "^ \*" | grep -v ^struct | grep -v "^[[:space:]]" | grep -v typedef | sed -e 's/(.*//g' -e 's/^const //g' -e 's/\*//g' | awk '{print $2}')"
 
-exportedapicalls="$(nm -B -D "$builddir"/../.libs/libknet.so | grep ' T ' | awk '{print $3}')"
+# The PowerPC64 ELFv1 ABI defines the address of a function as that of a
+# function descriptor defined in .opd, a data (D) section.  Other ABIs
+# use the entry address of the function itself in the text (T) section.
+exportedapicalls="$(nm -B -D "$builddir"/../.libs/libknet.so | grep ' [DT] ' | awk '{print $3}')"
 
 echo "Checking for exported symbols NOT available in header file"
 


### PR DESCRIPTION
The PowerPC64 ELFv1 ABI puts the function descriptor symbols there,
but why restrict the consistency check to the text section anyway?

Signed-off-by: Ferenc Wágner <wferi@debian.org>