### PR TITLE
Use LD_LIBRARY_PATH to find the build tree artifacts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,12 @@ AC_INIT([kronosnet],
 	[devel@lists.kronosnet.org])
 AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([1.13 dist-bzip2 dist-xz color-tests -Wno-portability subdir-objects])
+
+# Switch to RUNPATH by default and disable RPATH
+# it is necessary to have this done very early in ./configure
+# before libtool does linker detection.
+# see also: https://github.com/kronosnet/kronosnet/issues/107
+LDFLAGS="$LDFLAGS -Wl,--enable-new-dtags"
 LT_PREREQ([2.2.6])
 LT_INIT
 


### PR DESCRIPTION
The libtool wrapper scripts of the test binaries set LD_LIBRARY_PATH to
find the libknet library and its modules in the build tree, but RPATH
overrides this setting.  This is why RPATH is deprecated, so we switch
to RUNPATH instead by using --enable-new-dtags, which is already the
linker default on Debian for example.

Signed-off-by: Ferenc Wágner <wferi@debian.org>

Fixes #107.