### PR TITLE
Flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,10 @@ LT_PREREQ([2.2.6])
 # --enable-new-dtags: Use RUNPATH instead of RPATH.
 # It is necessary to have this done before libtool does linker detection.
 # See also: https://github.com/kronosnet/kronosnet/issues/107
+# --as-needed: Modern systems have builtin ceil() making -lm superfluous but
+# AC_SEARCH_LIBS can't detect this because it tests with a false prototype
 AX_CHECK_LINK_FLAG([-Wl,--enable-new-dtags],[AM_LDFLAGS=-Wl,--enable-new-dtags])
+AX_CHECK_LINK_FLAG([-Wl,--as-needed],[AM_LDFLAGS="$AM_LDFLAGS -Wl,--as-needed"])
 AC_SUBST([AM_LDFLAGS])
 saved_LDFLAGS="$LDFLAGS"
 LDFLAGS="$AM_LDFLAGS $LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -18,13 +18,15 @@ AC_INIT([kronosnet],
 AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([1.13 dist-bzip2 dist-xz color-tests -Wno-portability subdir-objects])
 
-# Switch to RUNPATH by default and disable RPATH
-# it is necessary to have this done very early in ./configure
-# before libtool does linker detection.
-# see also: https://github.com/kronosnet/kronosnet/issues/107
-LDFLAGS="$LDFLAGS -Wl,--enable-new-dtags"
 LT_PREREQ([2.2.6])
+# --enable-new-dtags: Use RUNPATH instead of RPATH.
+# It is necessary to have this done before libtool does linker detection.
+# See also: https://github.com/kronosnet/kronosnet/issues/107
+AC_SUBST([AM_LDFLAGS],["-Wl,--enable-new-dtags"])
+saved_LDFLAGS="$LDFLAGS"
+LDFLAGS="$AM_LDFLAGS $LDFLAGS"
 LT_INIT
+LDFLAGS="$saved_LDFLAGS"
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([kronosnetd/main.c])
@@ -368,7 +370,6 @@ AC_DEFINE_UNQUOTED([DEFAULTADMGROUP],
 ## *FLAGS handling
 ENV_CFLAGS="$CFLAGS"
 ENV_CPPFLAGS="$CPPFLAGS"
-ENV_LDFLAGS="$LDFLAGS"
 
 # debug build stuff
 if test "x${enable_debug}" = xyes; then
@@ -443,7 +444,6 @@ done
 CFLAGS="$ENV_CFLAGS $lt_prog_compiler_pic $OPT_CFLAGS $GDB_FLAGS \
 	$EXTRA_WARNINGS $WERROR_CFLAGS"
 CPPFLAGS="$ENV_CPPFLAGS"
-LDFLAGS="$ENV_LDFLAGS $lt_prog_compiler_pic"
 
 AC_CONFIG_FILES([
 		Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -191,8 +191,10 @@ AC_C_INLINE
 
 # Checks for libraries.
 AX_PTHREAD(,[AC_MSG_ERROR([POSIX threads support is required])])
-AC_CHECK_LIB([m], [ceil], [AC_SUBST([m_LIBS], [-lm])], [AC_MSG_ERROR([kronosnet requires m library])])
 saved_LIBS="$LIBS"
+LIBS=
+AC_SEARCH_LIBS([ceil], [m], , [AC_MSG_ERROR([ceil not found])])
+AC_SUBST([m_LIBS], [$LIBS])
 LIBS=
 AC_SEARCH_LIBS([clock_gettime], [rt], , [AC_MSG_ERROR([clock_gettime not found])])
 AC_SUBST([rt_LIBS], [$LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -326,8 +326,6 @@ DEFAULT_CONFIG_DIR=${sysconfdir}/kronosnet
 
 ## do subst
 
-AM_CONDITIONAL([DEBUG], [test "x${enable_debug}" = xyes])
-
 AC_SUBST([DEFAULT_CONFIG_DIR])
 AC_SUBST([INITDEFAULTDIR])
 AC_SUBST([INITDDIR])

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,8 @@ LT_PREREQ([2.2.6])
 # --enable-new-dtags: Use RUNPATH instead of RPATH.
 # It is necessary to have this done before libtool does linker detection.
 # See also: https://github.com/kronosnet/kronosnet/issues/107
-AC_SUBST([AM_LDFLAGS],["-Wl,--enable-new-dtags"])
+AX_CHECK_LINK_FLAG([-Wl,--enable-new-dtags],[AM_LDFLAGS=-Wl,--enable-new-dtags])
+AC_SUBST([AM_LDFLAGS])
 saved_LDFLAGS="$LDFLAGS"
 LDFLAGS="$AM_LDFLAGS $LDFLAGS"
 LT_INIT

--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ AM_CONDITIONAL([BUILD_LIBTAP], [test x$enable_libtap = xyes])
 
 ## local helper functions
 # this function checks if CC support options passed as
-# args. Global CFLAGS are ignored during this test.
+# args. Global CPPFLAGS are ignored during this test.
 cc_supports_flag() {
 	saveCPPFLAGS="$CPPFLAGS"
 	CPPFLAGS="$@"
@@ -369,7 +369,6 @@ AC_DEFINE_UNQUOTED([DEFAULTADMGROUP],
 
 ## *FLAGS handling
 ENV_CFLAGS="$CFLAGS"
-ENV_CPPFLAGS="$CPPFLAGS"
 
 # debug build stuff
 if test "x${enable_debug}" = xyes; then
@@ -443,7 +442,6 @@ done
 
 CFLAGS="$ENV_CFLAGS $lt_prog_compiler_pic $OPT_CFLAGS $GDB_FLAGS \
 	$EXTRA_WARNINGS $WERROR_CFLAGS"
-CPPFLAGS="$ENV_CPPFLAGS"
 
 AC_CONFIG_FILES([
 		Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,9 @@ AC_PREREQ([2.63])
 AC_INIT([kronosnet],
 	m4_esyscmd([build-aux/git-version-gen .tarball-version]),
 	[devel@lists.kronosnet.org])
+# Don't let AC_PROC_CC (invoked by AC_USE_SYSTEM_EXTENSIONS) replace
+# undefined CFLAGS with -g -O2, overriding our special OPT_CFLAGS.
+: ${CFLAGS=""}
 AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([1.13 dist-bzip2 dist-xz color-tests -Wno-portability subdir-objects])
 
@@ -367,9 +370,6 @@ AC_DEFINE_UNQUOTED([DEFAULTADMGROUP],
 		   ["$(eval echo ${DEFAULTADMGROUP})"],
 		   [Default admin group])
 
-## *FLAGS handling
-ENV_CFLAGS="$CFLAGS"
-
 # debug build stuff
 if test "x${enable_debug}" = xyes; then
 	AC_DEFINE_UNQUOTED([DEBUG], [1], [Compiling Debugging code])
@@ -440,8 +440,7 @@ for j in $WARNLIST; do
 	fi
 done
 
-CFLAGS="$ENV_CFLAGS $lt_prog_compiler_pic $OPT_CFLAGS $GDB_FLAGS \
-	$EXTRA_WARNINGS $WERROR_CFLAGS"
+AC_SUBST([AM_CFLAGS],["$OPT_CFLAGS $GDB_FLAGS $EXTRA_WARNINGS"])
 
 AC_CONFIG_FILES([
 		Makefile

--- a/kronosnetd/Makefile.am
+++ b/kronosnetd/Makefile.am
@@ -37,7 +37,7 @@ kronosnetd_CPPFLAGS	= \
 			  -I$(top_srcdir)/libtap \
 			  -I$(top_srcdir)/libknet
 
-kronosnetd_CFLAGS	= $(libqb_CFLAGS)
+kronosnetd_CFLAGS	= $(AM_CFLAGS) $(libqb_CFLAGS)
 
 kronosnetd_LDADD	= \
 			  $(top_builddir)/libknet/libknet.la \

--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -83,7 +83,8 @@ libknet_la_CFLAGS	= $(PTHREAD_CFLAGS)
 
 EXTRA_libknet_la_DEPENDENCIES	= $(SYMFILE)
 
-libknet_la_LDFLAGS	= -Wl,--version-script=$(srcdir)/$(SYMFILE) \
+libknet_la_LDFLAGS	= $(AM_LDFLAGS) \
+			  -Wl,--version-script=$(srcdir)/$(SYMFILE) \
 			  --export-dynamic \
 			  -Wl,-rpath=$(pkglibdir) \
 			  -version-number $(libversion)
@@ -93,54 +94,57 @@ libknet_la_LIBADD	= $(PTHREAD_LIBS) $(dl_LIBS) $(rt_LIBS) $(m_LIBS)
 # Prepare empty value for appending
 pkglib_LTLIBRARIES	=
 
+# MODULE_LDFLAGS would mean a target-specific variable for Automake
+MODULELDFLAGS		= $(AM_LDFLAGS) -module -avoid-version
+
 if BUILD_COMPRESS_ZLIB
 pkglib_LTLIBRARIES	+= compress_zlib.la
-compress_zlib_la_LDFLAGS = -module -avoid-version
+compress_zlib_la_LDFLAGS = $(MODULELDFLAGS)
 compress_zlib_la_CFLAGS	= $(zlib_CFLAGS)
 compress_zlib_la_LIBADD	= $(zlib_LIBS)
 endif
 
 if BUILD_COMPRESS_LZ4
 pkglib_LTLIBRARIES	+= compress_lz4.la compress_lz4hc.la
-compress_lz4_la_LDFLAGS	= -module -avoid-version
+compress_lz4_la_LDFLAGS	= $(MODULELDFLAGS)
 compress_lz4_la_CFLAGS	= $(liblz4_CFLAGS)
 compress_lz4_la_LIBADD	= $(liblz4_LIBS)
-compress_lz4hc_la_LDFLAGS = -module -avoid-version
+compress_lz4hc_la_LDFLAGS = $(MODULELDFLAGS)
 compress_lz4hc_la_CFLAGS = $(liblz4_CFLAGS)
 compress_lz4hc_la_LIBADD = $(liblz4_LIBS)
 endif
 
 if BUILD_COMPRESS_LZO2
 pkglib_LTLIBRARIES	+= compress_lzo2.la
-compress_lzo2_la_LDFLAGS = -module -avoid-version
+compress_lzo2_la_LDFLAGS = $(MODULELDFLAGS)
 compress_lzo2_la_CFLAGS	= $(lzo2_CFLAGS)
 compress_lzo2_la_LIBADD	= $(lzo2_LIBS)
 endif
 
 if BUILD_COMPRESS_LZMA
 pkglib_LTLIBRARIES	+= compress_lzma.la
-compress_lzma_la_LDFLAGS = -module -avoid-version
+compress_lzma_la_LDFLAGS = $(MODULELDFLAGS)
 compress_lzma_la_CFLAGS	= $(liblzma_CFLAGS)
 compress_lzma_la_LIBADD	= $(liblzma_LIBS)
 endif
 
 if BUILD_COMPRESS_BZIP2
 pkglib_LTLIBRARIES	+= compress_bzip2.la
-compress_bzip2_la_LDFLAGS = -module -avoid-version
+compress_bzip2_la_LDFLAGS = $(MODULELDFLAGS)
 compress_bzip2_la_CFLAGS = $(bzip2_CFLAGS)
 compress_bzip2_la_LIBADD = $(bzip2_LIBS)
 endif
 
 if BUILD_CRYPTO_NSS
 pkglib_LTLIBRARIES	+= crypto_nss.la
-crypto_nss_la_LDFLAGS	= -module -avoid-version
+crypto_nss_la_LDFLAGS	= $(MODULELDFLAGS)
 crypto_nss_la_CFLAGS	= $(nss_CFLAGS)
 crypto_nss_la_LIBADD	= $(nss_LIBS)
 endif
 
 if BUILD_CRYPTO_OPENSSL
 pkglib_LTLIBRARIES	+= crypto_openssl.la
-crypto_openssl_la_LDFLAGS = -module -avoid-version
+crypto_openssl_la_LDFLAGS = $(MODULELDFLAGS)
 crypto_openssl_la_CFLAGS = $(openssl_CFLAGS)
 crypto_openssl_la_LIBADD = $(openssl_LIBS)
 endif

--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -79,7 +79,7 @@ lib_LTLIBRARIES		= libknet.la
 
 libknet_la_SOURCES	= $(sources)
 
-libknet_la_CFLAGS	= $(PTHREAD_CFLAGS)
+libknet_la_CFLAGS	= $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 
 EXTRA_libknet_la_DEPENDENCIES	= $(SYMFILE)
 
@@ -100,52 +100,52 @@ MODULELDFLAGS		= $(AM_LDFLAGS) -module -avoid-version
 if BUILD_COMPRESS_ZLIB
 pkglib_LTLIBRARIES	+= compress_zlib.la
 compress_zlib_la_LDFLAGS = $(MODULELDFLAGS)
-compress_zlib_la_CFLAGS	= $(zlib_CFLAGS)
+compress_zlib_la_CFLAGS	= $(AM_CFLAGS) $(zlib_CFLAGS)
 compress_zlib_la_LIBADD	= $(zlib_LIBS)
 endif
 
 if BUILD_COMPRESS_LZ4
 pkglib_LTLIBRARIES	+= compress_lz4.la compress_lz4hc.la
 compress_lz4_la_LDFLAGS	= $(MODULELDFLAGS)
-compress_lz4_la_CFLAGS	= $(liblz4_CFLAGS)
+compress_lz4_la_CFLAGS	= $(AM_CFLAGS) $(liblz4_CFLAGS)
 compress_lz4_la_LIBADD	= $(liblz4_LIBS)
 compress_lz4hc_la_LDFLAGS = $(MODULELDFLAGS)
-compress_lz4hc_la_CFLAGS = $(liblz4_CFLAGS)
+compress_lz4hc_la_CFLAGS = $(AM_CFLAGS) $(liblz4_CFLAGS)
 compress_lz4hc_la_LIBADD = $(liblz4_LIBS)
 endif
 
 if BUILD_COMPRESS_LZO2
 pkglib_LTLIBRARIES	+= compress_lzo2.la
 compress_lzo2_la_LDFLAGS = $(MODULELDFLAGS)
-compress_lzo2_la_CFLAGS	= $(lzo2_CFLAGS)
+compress_lzo2_la_CFLAGS	= $(AM_CFLAGS) $(lzo2_CFLAGS)
 compress_lzo2_la_LIBADD	= $(lzo2_LIBS)
 endif
 
 if BUILD_COMPRESS_LZMA
 pkglib_LTLIBRARIES	+= compress_lzma.la
 compress_lzma_la_LDFLAGS = $(MODULELDFLAGS)
-compress_lzma_la_CFLAGS	= $(liblzma_CFLAGS)
+compress_lzma_la_CFLAGS	= $(AM_CFLAGS) $(liblzma_CFLAGS)
 compress_lzma_la_LIBADD	= $(liblzma_LIBS)
 endif
 
 if BUILD_COMPRESS_BZIP2
 pkglib_LTLIBRARIES	+= compress_bzip2.la
 compress_bzip2_la_LDFLAGS = $(MODULELDFLAGS)
-compress_bzip2_la_CFLAGS = $(bzip2_CFLAGS)
+compress_bzip2_la_CFLAGS = $(AM_CFLAGS) $(bzip2_CFLAGS)
 compress_bzip2_la_LIBADD = $(bzip2_LIBS)
 endif
 
 if BUILD_CRYPTO_NSS
 pkglib_LTLIBRARIES	+= crypto_nss.la
 crypto_nss_la_LDFLAGS	= $(MODULELDFLAGS)
-crypto_nss_la_CFLAGS	= $(nss_CFLAGS)
+crypto_nss_la_CFLAGS	= $(AM_CFLAGS) $(nss_CFLAGS)
 crypto_nss_la_LIBADD	= $(nss_LIBS)
 endif
 
 if BUILD_CRYPTO_OPENSSL
 pkglib_LTLIBRARIES	+= crypto_openssl.la
 crypto_openssl_la_LDFLAGS = $(MODULELDFLAGS)
-crypto_openssl_la_CFLAGS = $(openssl_CFLAGS)
+crypto_openssl_la_CFLAGS = $(AM_CFLAGS) $(openssl_CFLAGS)
 crypto_openssl_la_LIBADD = $(openssl_LIBS)
 endif
 

--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -85,7 +85,6 @@ EXTRA_libknet_la_DEPENDENCIES	= $(SYMFILE)
 
 libknet_la_LDFLAGS	= $(AM_LDFLAGS) \
 			  -Wl,--version-script=$(srcdir)/$(SYMFILE) \
-			  --export-dynamic \
 			  -Wl,-rpath=$(pkglibdir) \
 			  -version-number $(libversion)
 
@@ -95,7 +94,7 @@ libknet_la_LIBADD	= $(PTHREAD_LIBS) $(dl_LIBS) $(rt_LIBS) $(m_LIBS)
 pkglib_LTLIBRARIES	=
 
 # MODULE_LDFLAGS would mean a target-specific variable for Automake
-MODULELDFLAGS		= $(AM_LDFLAGS) -module -avoid-version
+MODULELDFLAGS		= $(AM_LDFLAGS) -module -avoid-version -export-dynamic
 
 if BUILD_COMPRESS_ZLIB
 pkglib_LTLIBRARIES	+= compress_zlib.la

--- a/libknet/tests/Makefile.am
+++ b/libknet/tests/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST		= \
 			  api-check.mk
 
 AM_CPPFLAGS		= -I$(top_srcdir)/libknet
-AM_CFLAGS		= $(PTHREAD_CFLAGS)
+AM_CFLAGS		+= $(PTHREAD_CFLAGS)
 LIBS			= $(top_builddir)/libknet/libknet.la \
 			  $(PTHREAD_LIBS) $(dl_LIBS)
 

--- a/libtap/Makefile.am
+++ b/libtap/Makefile.am
@@ -36,7 +36,8 @@ libtap_la_SOURCES	= $(sources)
 
 EXTRA_libtap_la_DEPENDENCIES	= $(SYMFILE)
 
-libtap_la_LDFLAGS	= -Wl,-version-script,$(srcdir)/$(SYMFILE) \
+libtap_la_LDFLAGS	= $(AM_LDFLAGS) \
+			  -Wl,-version-script,$(srcdir)/$(SYMFILE) \
 			  --export-dynamic \
 			  -version-number $(libversion)
 

--- a/libtap/Makefile.am
+++ b/libtap/Makefile.am
@@ -19,7 +19,7 @@ sources			= libtap.c
 
 libversion		= 1:0:0
 
-AM_CFLAGS		= $(PTHREAD_CFLAGS)
+AM_CFLAGS		+= $(PTHREAD_CFLAGS)
 LIBS			= $(PTHREAD_LIBS)
 
 if BUILD_LIBTAP

--- a/libtap/Makefile.am
+++ b/libtap/Makefile.am
@@ -38,7 +38,6 @@ EXTRA_libtap_la_DEPENDENCIES	= $(SYMFILE)
 
 libtap_la_LDFLAGS	= $(AM_LDFLAGS) \
 			  -Wl,-version-script,$(srcdir)/$(SYMFILE) \
-			  --export-dynamic \
 			  -version-number $(libversion)
 
 TESTS			= $(check_PROGRAMS)

--- a/m4/ax_check_link_flag.m4
+++ b/m4/ax_check_link_flag.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 5
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS

--- a/poc-code/iov-hash/Makefile.am
+++ b/poc-code/iov-hash/Makefile.am
@@ -19,4 +19,4 @@ nss_hash_SOURCES	= main.c
 
 nss_hash_CFLAGS		= $(nss_CFLAGS)
 
-nss_hash_LDFLAGS	= $(nss_LIBS)
+nss_hash_LDADD		= $(nss_LIBS)

--- a/poc-code/iov-hash/Makefile.am
+++ b/poc-code/iov-hash/Makefile.am
@@ -17,6 +17,6 @@ noinst_PROGRAMS		= nss_hash
 
 nss_hash_SOURCES	= main.c
 
-nss_hash_CFLAGS		= $(nss_CFLAGS)
+nss_hash_CFLAGS		= $(AM_CFLAGS) $(nss_CFLAGS)
 
 nss_hash_LDADD		= $(nss_LIBS)


### PR DESCRIPTION
These changes align the handling of various FLAGS variables with the GNU coding standards. The main point is letting the user have the last word on the compiler/linker options by specifying `CFLAGS` and such.
The second part is checking for linker flags before use and some minor issues I happened to stumble upon.