### PR TITLE
doxyxml: use AM_CFLAGS for debugging info, optimization and warnings

### DIFF
--- a/build-aux/Makefile.am
+++ b/build-aux/Makefile.am
@@ -17,5 +17,5 @@ EXTRA_DIST	= check.mk gitlog-to-changelog git-version-gen \
 noinst_PROGRAMS	= doxyxml
 
 doxyxml_SOURCES = doxyxml.c
-doxyxml_CFLAGS = $(libqb_CFLAGS) $(libxml_CFLAGS)
+doxyxml_CFLAGS = $(AM_CFLAGS) $(libqb_CFLAGS) $(libxml_CFLAGS)
 doxyxml_LDADD = $(libqb_LIBS) $(libxml_LIBS)


### PR DESCRIPTION
The rework of the FLAGS handling and the development of doxyxml happened
on different temporary branches, and this slipped through on the merge.

Signed-off-by: Ferenc Wágner <wferi@debian.org>