### PR TITLE
Cross-compilation support

### DIFF
--- a/build-aux/Makefile.am
+++ b/build-aux/Makefile.am
@@ -14,8 +14,15 @@ EXTRA_DIST	= check.mk gitlog-to-changelog git-version-gen \
 		  knet_valgrind_helgrind.supp knet_valgrind_memcheck.supp \
 		  release.mk update-copyright.sh
 
+EXEEXT=$(BUILD_EXEEXT)
+
 noinst_PROGRAMS	= doxyxml
+
+$(doxyxml_OBJECTS) : CC=$(CC_FOR_BUILD)
+$(doxyxml_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
+$(doxyxml_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
 
 doxyxml_SOURCES = doxyxml.c
 doxyxml_CFLAGS = $(AM_CFLAGS) $(libqb_CFLAGS) $(libxml_CFLAGS)
 doxyxml_LDADD = $(libqb_LIBS) $(libxml_LIBS)
+doxyxml_LINK = $(CC_FOR_BUILD) $(doxyxml_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@

--- a/build-aux/Makefile.am
+++ b/build-aux/Makefile.am
@@ -25,4 +25,4 @@ $(doxyxml_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
 doxyxml_SOURCES = doxyxml.c
 doxyxml_CFLAGS = $(AM_CFLAGS) $(libqb_BUILD_CFLAGS) $(libxml_BUILD_CFLAGS)
 doxyxml_LDADD = $(libqb_BUILD_LIBS) $(libxml_BUILD_LIBS)
-doxyxml_LINK = $(CC_FOR_BUILD) $(doxyxml_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
+doxyxml_LINK = $(CC_FOR_BUILD) $(doxyxml_CFLAGS) $(CFLAGS_FOR_BUILD) $(AM_LDFLAGS) $(LDFLAGS_FOR_BUILD) -o $@

--- a/build-aux/Makefile.am
+++ b/build-aux/Makefile.am
@@ -14,15 +14,17 @@ EXTRA_DIST	= check.mk gitlog-to-changelog git-version-gen \
 		  knet_valgrind_helgrind.supp knet_valgrind_memcheck.supp \
 		  release.mk update-copyright.sh
 
+# Avoid Automake warnings about overriding these user variables.
+# Programs in this directory are used during the build only.
+AUTOMAKE_OPTIONS = -Wno-gnu
 EXEEXT=$(BUILD_EXEEXT)
+CC=$(CC_FOR_BUILD)
+CFLAGS=$(CFLAGS_FOR_BUILD)
+CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
+LDFLAGS=$(LDFLAGS_FOR_BUILD)
 
 noinst_PROGRAMS	= doxyxml
-
-$(doxyxml_OBJECTS) : CC=$(CC_FOR_BUILD)
-$(doxyxml_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
-$(doxyxml_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
 
 doxyxml_SOURCES = doxyxml.c
 doxyxml_CFLAGS = $(AM_CFLAGS) $(libqb_BUILD_CFLAGS) $(libxml_BUILD_CFLAGS)
 doxyxml_LDADD = $(libqb_BUILD_LIBS) $(libxml_BUILD_LIBS)
-doxyxml_LINK = $(CC_FOR_BUILD) $(doxyxml_CFLAGS) $(CFLAGS_FOR_BUILD) $(AM_LDFLAGS) $(LDFLAGS_FOR_BUILD) -o $@

--- a/build-aux/Makefile.am
+++ b/build-aux/Makefile.am
@@ -23,6 +23,6 @@ $(doxyxml_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
 $(doxyxml_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
 
 doxyxml_SOURCES = doxyxml.c
-doxyxml_CFLAGS = $(AM_CFLAGS) $(libqb_CFLAGS) $(libxml_CFLAGS)
-doxyxml_LDADD = $(libqb_LIBS) $(libxml_LIBS)
+doxyxml_CFLAGS = $(AM_CFLAGS) $(libqb_BUILD_CFLAGS) $(libxml_BUILD_CFLAGS)
+doxyxml_LDADD = $(libqb_BUILD_LIBS) $(libxml_BUILD_LIBS)
 doxyxml_LINK = $(CC_FOR_BUILD) $(doxyxml_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@

--- a/configure.ac
+++ b/configure.ac
@@ -270,9 +270,15 @@ if test "x$ac_cv_header_sys_epoll_h" = xyes && test "x$ac_cv_func_kevent" = xyes
 	AC_MSG_ERROR([Both epoll and kevent available on this OS, please contact the maintainers to fix the code])
 fi
 
-# required by doxyman to build man pages dynamically
+# required by doxyxml to build man pages dynamically
+saved_PKG_CONFIG="$PKG_CONFIG"
+saved_ac_cv_path_PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
+unset PKG_CONFIG ac_cv_path_PKG_CONFIG
+AC_PATH_PROG([PKG_CONFIG], [pkg-config])
 PKG_CHECK_MODULES([libqb], [libqb])
 PKG_CHECK_MODULES([libxml], [libxml-2.0])
+PKG_CONFIG="$saved_PKG_CONFIG"
+ac_cv_path_PKG_CONFIG="$saved_ac_cv_path_PKG_CONFIG"
 
 # checks (for kronosnetd)
 if test "x$enable_kronosnetd" = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -276,8 +276,8 @@ saved_PKG_CONFIG="$PKG_CONFIG"
 saved_ac_cv_path_PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
 unset PKG_CONFIG ac_cv_path_PKG_CONFIG
 AC_PATH_PROG([PKG_CONFIG], [pkg-config])
-PKG_CHECK_MODULES([libqb], [libqb])
-PKG_CHECK_MODULES([libxml], [libxml-2.0])
+PKG_CHECK_MODULES([libqb_BUILD], [libqb])
+PKG_CHECK_MODULES([libxml_BUILD], [libxml-2.0])
 PKG_CONFIG="$saved_PKG_CONFIG"
 ac_cv_path_PKG_CONFIG="$saved_ac_cv_path_PKG_CONFIG"
 
@@ -292,6 +292,8 @@ if test "x$enable_kronosnetd" = xyes; then
 			 [AC_CHECK_LIB([pam_misc], [misc_conv],
 				       [AC_SUBST([pam_misc_LIBS], [-lpam_misc])],
 				       [AC_MSG_ERROR([Unable to find LinuxPAM MISC devel files])])])
+
+	PKG_CHECK_MODULES([libqb], [libqb])
 
 	AC_CHECK_LIB([qb], [qb_log_thread_priority_set],
 		     [have_qb_log_thread_priority_set="yes"],

--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,7 @@ if test "x$ac_cv_header_sys_epoll_h" = xyes && test "x$ac_cv_func_kevent" = xyes
 fi
 
 # required by doxyxml to build man pages dynamically
+AX_PROG_CC_FOR_BUILD
 saved_PKG_CONFIG="$PKG_CONFIG"
 saved_ac_cv_path_PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
 unset PKG_CONFIG ac_cv_path_PKG_CONFIG

--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,9 @@ if test "x$ac_cv_header_sys_epoll_h" = xyes && test "x$ac_cv_func_kevent" = xyes
 fi
 
 # required by doxyxml to build man pages dynamically
+# Don't let AC_PROC_CC (invoked by AX_PROG_CC_FOR_BUILD) replace
+# undefined CFLAGS_FOR_BUILD with -g -O2, overriding our special OPT_CFLAGS.
+: ${CFLAGS_FOR_BUILD=""}
 AX_PROG_CC_FOR_BUILD
 saved_PKG_CONFIG="$PKG_CONFIG"
 saved_ac_cv_path_PKG_CONFIG="$ac_cv_path_PKG_CONFIG"

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -1,0 +1,125 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_prog_cc_for_build.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_CC_FOR_BUILD
+#
+# DESCRIPTION
+#
+#   This macro searches for a C compiler that generates native executables,
+#   that is a C compiler that surely is not a cross-compiler. This can be
+#   useful if you have to generate source code at compile-time like for
+#   example GCC does.
+#
+#   The macro sets the CC_FOR_BUILD and CPP_FOR_BUILD macros to anything
+#   needed to compile or link (CC_FOR_BUILD) and preprocess (CPP_FOR_BUILD).
+#   The value of these variables can be overridden by the user by specifying
+#   a compiler with an environment variable (like you do for standard CC).
+#
+#   It also sets BUILD_EXEEXT and BUILD_OBJEXT to the executable and object
+#   file extensions for the build platform, and GCC_FOR_BUILD to `yes' if
+#   the compiler we found is GCC. All these variables but GCC_FOR_BUILD are
+#   substituted in the Makefile.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Paolo Bonzini <bonzini@gnu.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 9
+
+AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
+AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
+AC_REQUIRE([AC_PROG_CC])dnl
+AC_REQUIRE([AC_PROG_CPP])dnl
+AC_REQUIRE([AC_EXEEXT])dnl
+AC_REQUIRE([AC_CANONICAL_HOST])dnl
+
+dnl Use the standard macros, but make them use other variable names
+dnl
+pushdef([ac_cv_prog_CPP], ac_cv_build_prog_CPP)dnl
+pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
+pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
+pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
+pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
+pushdef([ac_cv_exeext], ac_cv_build_exeext)dnl
+pushdef([ac_cv_objext], ac_cv_build_objext)dnl
+pushdef([ac_exeext], ac_build_exeext)dnl
+pushdef([ac_objext], ac_build_objext)dnl
+pushdef([CC], CC_FOR_BUILD)dnl
+pushdef([CPP], CPP_FOR_BUILD)dnl
+pushdef([CFLAGS], CFLAGS_FOR_BUILD)dnl
+pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
+pushdef([LDFLAGS], LDFLAGS_FOR_BUILD)dnl
+pushdef([host], build)dnl
+pushdef([host_alias], build_alias)dnl
+pushdef([host_cpu], build_cpu)dnl
+pushdef([host_vendor], build_vendor)dnl
+pushdef([host_os], build_os)dnl
+pushdef([ac_cv_host], ac_cv_build)dnl
+pushdef([ac_cv_host_alias], ac_cv_build_alias)dnl
+pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
+pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
+pushdef([ac_cv_host_os], ac_cv_build_os)dnl
+pushdef([ac_cpp], ac_build_cpp)dnl
+pushdef([ac_compile], ac_build_compile)dnl
+pushdef([ac_link], ac_build_link)dnl
+
+save_cross_compiling=$cross_compiling
+save_ac_tool_prefix=$ac_tool_prefix
+cross_compiling=no
+ac_tool_prefix=
+
+AC_PROG_CC
+AC_PROG_CPP
+AC_EXEEXT
+
+ac_tool_prefix=$save_ac_tool_prefix
+cross_compiling=$save_cross_compiling
+
+dnl Restore the old definitions
+dnl
+popdef([ac_link])dnl
+popdef([ac_compile])dnl
+popdef([ac_cpp])dnl
+popdef([ac_cv_host_os])dnl
+popdef([ac_cv_host_vendor])dnl
+popdef([ac_cv_host_cpu])dnl
+popdef([ac_cv_host_alias])dnl
+popdef([ac_cv_host])dnl
+popdef([host_os])dnl
+popdef([host_vendor])dnl
+popdef([host_cpu])dnl
+popdef([host_alias])dnl
+popdef([host])dnl
+popdef([LDFLAGS])dnl
+popdef([CPPFLAGS])dnl
+popdef([CFLAGS])dnl
+popdef([CPP])dnl
+popdef([CC])dnl
+popdef([ac_objext])dnl
+popdef([ac_exeext])dnl
+popdef([ac_cv_objext])dnl
+popdef([ac_cv_exeext])dnl
+popdef([ac_cv_prog_cc_g])dnl
+popdef([ac_cv_prog_cc_cross])dnl
+popdef([ac_cv_prog_cc_works])dnl
+popdef([ac_cv_prog_gcc])dnl
+popdef([ac_cv_prog_CPP])dnl
+
+dnl Finally, set Makefile variables
+dnl
+BUILD_EXEEXT=$ac_build_exeext
+BUILD_OBJEXT=$ac_build_objext
+AC_SUBST(BUILD_EXEEXT)dnl
+AC_SUBST(BUILD_OBJEXT)dnl
+AC_SUBST([CFLAGS_FOR_BUILD])dnl
+AC_SUBST([CPPFLAGS_FOR_BUILD])dnl
+AC_SUBST([LDFLAGS_FOR_BUILD])dnl
+])


### PR DESCRIPTION
As discussed in #131, cross-compilation support might be useful even if we can avoid it by making documentation generation optional.
The last change is somewhat matter of taste, but I think `build-aux/Makefile.am` communicates (my interpretation of) the intent more clearly this way.
(Merging this resolves #131.)