### PR TITLE
UDP: Don't keep retrying send if we get EINVAL

### DIFF
--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -401,6 +401,9 @@ int udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, 
 			read_errs_from_sock(knet_h, sockfd);
 			return 0;
 		}
+		if (recv_errno == EINVAL) {
+			return -1;
+		}
 		if ((recv_errno == ENOBUFS) || (recv_errno == EAGAIN)) {
 #ifdef DEBUG
 			log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is overloaded. Slowing TX down", sockfd);


### PR DESCRIPTION
UDP can return EINVAL if the route is down or not configured, this can
cause knet to 'spin' (well, ish, there is a usleep in there).

With this patch in place knet doesn't hog the CPU anywhere near so much
(and it does recover if the link returns).

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>