### PR TITLE
[tx/rx] improve error checking when running external code

### DIFF
--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -452,6 +452,10 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 
 				/* check if we are dst for this packet */
 				if (!bcast) {
+					if (dst_host_ids_entries > KNET_MAX_HOST) {
+						log_debug(knet_h, KNET_SUB_RX, "dst_host_filter_fn returned too many destinations");
+						return;
+					}
 					for (host_idx = 0; host_idx < dst_host_ids_entries; host_idx++) {
 						if (dst_host_ids[host_idx] == knet_h->host_id) {
 							found = 1;

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -195,6 +195,14 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 					err = -1;
 					goto out_unlock;
 				}
+
+				if ((!bcast) &&
+				    (dst_host_ids_entries_temp > KNET_MAX_HOST)) {
+					log_debug(knet_h, KNET_SUB_TX, "dst_host_filter_fn returned too many destinations");
+					savederrno = EINVAL;
+					err = -1;
+					goto out_unlock;
+				}
 			}
 
 			/* Send to localhost if appropriate and enabled */


### PR DESCRIPTION
libknet cannot guarantee that the dst_host_filter is sane nor that it cannot
be exploited to return garbage to knet.

there is an infinitesimal possibility that, if the plugin returns total crap,
knet could crash by trying to access out-of-bound memory.

Prevent that by adding specific checks both in TX/RX.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>