### PR TITLE
[compress] delegate compress_level validation to compress libraries

### DIFF
--- a/build-aux/knet_valgrind_memcheck.supp
+++ b/build-aux/knet_valgrind_memcheck.supp
@@ -460,6 +460,22 @@
    fun:start_thread
 }
 {
+   lzma internal stuff (Debian / Ubuntu)
+   Memcheck:Cond
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   fun:lzma_block_buffer_encode
+   fun:lzma_stream_buffer_encode
+   fun:lzma_easy_buffer_encode
+   fun:lzma_compress
+   fun:compress_lib_test
+   fun:compress_cfg
+   fun:knet_handle_compress
+   fun:test
+}
+{
    lzma internal stuff (Ubuntu 17.10 i386)
    Memcheck:Cond
    obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
@@ -492,6 +508,22 @@
    fun:_parse_recv_from_sock
    fun:_handle_send_to_links
    fun:_handle_send_to_links_thread
+}
+{
+   lzma internal stuff (Ubuntu 17.10 i386)
+   Memcheck:Cond
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   fun:lzma_stream_buffer_encode
+   fun:lzma_easy_buffer_encode
+   fun:lzma_compress
+   fun:compress_lib_test
+   fun:compress_cfg
+   fun:knet_handle_compress
 }
 {
    nss internal stuff (FreeBSD 11.1)

--- a/libknet/compress.c
+++ b/libknet/compress.c
@@ -193,6 +193,7 @@ static int compress_lib_test(knet_handle_t knet_h)
 	unsigned char src[KNET_DATABUFSIZE];
 	unsigned char dst[KNET_DATABUFSIZE_COMPRESS];
 	ssize_t dst_comp_len = KNET_DATABUFSIZE_COMPRESS, dst_decomp_len = KNET_DATABUFSIZE;
+	unsigned int i;
 
 	memset(src, 0, KNET_DATABUFSIZE);
 	memset(dst, 0, KNET_DATABUFSIZE_COMPRESS);
@@ -214,6 +215,14 @@ static int compress_lib_test(knet_handle_t knet_h)
 		log_err(knet_h, KNET_SUB_COMPRESS, "Unable to decompress test buffer. Please check your compression settings: %s", strerror(savederrno));
 		errno = savederrno;
 		return -1;
+	}
+
+	for (i = 0; i < KNET_DATABUFSIZE; i++) {
+		if (src[i] != 0) {
+			log_err(knet_h, KNET_SUB_COMPRESS, "Decompressed buffer contains incorrect data");
+			errno = EINVAL;
+			return -1;
+		}
 	}
 
 	return 0;

--- a/libknet/compress_bzip2.c
+++ b/libknet/compress_bzip2.c
@@ -15,18 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int bzip2_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if ((compress_level < 1) || (compress_level > 9)) {
-                log_err(knet_h, KNET_SUB_BZIP2COMP, "bzip2 unsupported compression level %d (accepted values from 1 to 9)", compress_level);
-		errno = EINVAL;
-		return -1;
-	}
-	return 0;
-}
-
 static int bzip2_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -120,7 +108,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	bzip2_val_level,
+	NULL,
 	bzip2_compress,
 	bzip2_decompress
 };

--- a/libknet/compress_lz4.c
+++ b/libknet/compress_lz4.c
@@ -15,17 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int lz4_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if (compress_level <= 0) {
-		log_info(knet_h, KNET_SUB_LZ4COMP, "lz4 acceleration level 0 (or negatives) are automatically remapped to 1");
-	}
-
-	return 0;
-}
-
 static int lz4_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -96,7 +85,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	lz4_val_level,
+	NULL,
 	lz4_compress,
 	lz4_decompress
 };

--- a/libknet/compress_lz4hc.c
+++ b/libknet/compress_lz4hc.c
@@ -32,27 +32,6 @@
 #define KNET_LZ4HC_MAX 16
 #endif
 
-static int lz4hc_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if (compress_level < 1) {
-		log_err(knet_h, KNET_SUB_LZ4HCCOMP, "lz4hc supports only 1+ values for compression level");
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (compress_level < 4) {
-		log_info(knet_h, KNET_SUB_LZ4HCCOMP, "lz4hc recommends 4+ compression level for better results");
-	}
-
-	if (compress_level > KNET_LZ4HC_MAX) {
-		log_warn(knet_h, KNET_SUB_LZ4HCCOMP, "lz4hc installed on this system supports up to compression level %d. Higher values behaves as %d", KNET_LZ4HC_MAX, KNET_LZ4HC_MAX);
-	}
-
-	return 0;
-}
-
 static int lz4hc_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -117,7 +96,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	lz4hc_val_level,
+	NULL,
 	lz4hc_compress,
 	lz4_decompress
 };

--- a/libknet/compress_lzma.c
+++ b/libknet/compress_lzma.c
@@ -15,19 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int lzma_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if ((compress_level < 0) || (compress_level > 9)) {
-                log_err(knet_h, KNET_SUB_LZMACOMP, "lzma unsupported compression preset %d (accepted values from 0 to 9)", compress_level);
-		errno = EINVAL;
-		return -1;
-	}
-
-	return 0;
-}
-
 static int lzma_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -132,7 +119,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	lzma_val_level,
+	NULL,
 	lzma_compress,
 	lzma_decompress
 };

--- a/libknet/compress_model.h
+++ b/libknet/compress_model.h
@@ -48,8 +48,6 @@ typedef struct {
 	 */
 
 	/*
-	 * required functions
-	 *
 	 * val_level is called upon compress configuration changes
 	 * to make sure that the requested compress_level is valid
 	 * within the context of a given module.
@@ -58,6 +56,8 @@ typedef struct {
 			 int compress_level);
 
 	/*
+	 * required functions
+	 *
 	 * hopefully those 2 don't require any explanation....
 	 */
 	int (*compress)	(knet_handle_t knet_h,

--- a/libknet/compress_zlib.c
+++ b/libknet/compress_zlib.c
@@ -15,25 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int zlib_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if (compress_level < 0) {
-		log_err(knet_h, KNET_SUB_ZLIBCOMP, "zlib does not support negative compression level %d",
-			 compress_level);
-		return -1;
-	}
-	if (compress_level > 9) {
-		log_err(knet_h, KNET_SUB_ZLIBCOMP, "zlib does not support compression level higher than 9");
-		return -1;
-	}
-	if (compress_level == 0) {
-		log_warn(knet_h, KNET_SUB_ZLIBCOMP, "zlib compress level 0 does NOT perform any compression");
-	}
-	return 0;
-}
-
 static int zlib_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -130,7 +111,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	zlib_val_level,
+	NULL,
 	zlib_compress,
 	zlib_decompress
 };

--- a/libknet/tests/api_knet_handle_compress.c
+++ b/libknet/tests/api_knet_handle_compress.c
@@ -81,14 +81,14 @@ static void test(void)
 
 	flush_logs(logfds[0], stdout);
 
-	printf("Test knet_handle_compress with zlib compress and negative level\n");
+	printf("Test knet_handle_compress with zlib compress and negative level (-2)\n");
 
 	memset(&knet_handle_compress_cfg, 0, sizeof(struct knet_handle_compress_cfg));
 	strncpy(knet_handle_compress_cfg.compress_model, "zlib", sizeof(knet_handle_compress_cfg.compress_model) - 1);
-	knet_handle_compress_cfg.compress_level = -1;
+	knet_handle_compress_cfg.compress_level = -2;
 
 	if ((!knet_handle_compress(knet_h, &knet_handle_compress_cfg)) || (errno != EINVAL)) {
-		printf("knet_handle_compress accepted invalid (-1) compress level for zlib\n");
+		printf("knet_handle_compress accepted invalid (-2) compress level for zlib\n");
 		knet_handle_free(knet_h);
 		flush_logs(logfds[0], stdout);
 		close_logpipes(logfds);


### PR DESCRIPTION
- make val_level internal api call optional
- keep lzo2 val_level around due to the specific nature of compress_level values
- add internal compress_lib_test to do a round-robin (compress/decompress) check with provided values
- drop unnecessary val_level checks around
- update internal compress API include file
- adjust api_knet_handle_compress test to use a known bad value for zlib validation

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>