### PR TITLE
stable1-proposed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+configure.ac export-subst

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ distclean-local:
 
 $(SPEC): $(SPEC).in .version config.status
 	rm -f $@-t $@
-	date="`LC_ALL=C date "+%a %b %d %Y"`" && \
+	date="`LC_ALL=C date -d "@$(SOURCE_EPOCH)" "+%a %b %d %Y"`" && \
 	if [ -f $(abs_srcdir)/.tarball-version ]; then \
 		gitver="`cat $(abs_srcdir)/.tarball-version`" && \
 		rpmver=$$gitver && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ distclean-local:
 
 $(SPEC): $(SPEC).in .version config.status
 	rm -f $@-t $@
-	date="`LC_ALL=C date -d "@$(SOURCE_EPOCH)" "+%a %b %d %Y"`" && \
+	date="`LC_ALL=C $(UTC_DATE_AT)$(SOURCE_EPOCH) "+%a %b %d %Y"`" && \
 	if [ -f $(abs_srcdir)/.tarball-version ]; then \
 		gitver="`cat $(abs_srcdir)/.tarball-version`" && \
 		rpmver=$$gitver && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ BUILT_SOURCES	= .version
 
 dist-hook: gen-ChangeLog
 	echo $(VERSION) > $(distdir)/.tarball-version
+	echo $(SOURCE_EPOCH) > $(distdir)/source_epoch
 
 gen_start_date = 2000-01-01
 .PHONY: gen-ChangeLog

--- a/build-aux/knet_valgrind_memcheck.supp
+++ b/build-aux/knet_valgrind_memcheck.supp
@@ -460,6 +460,22 @@
    fun:start_thread
 }
 {
+   lzma internal stuff (Debian / Ubuntu)
+   Memcheck:Cond
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   fun:lzma_block_buffer_encode
+   fun:lzma_stream_buffer_encode
+   fun:lzma_easy_buffer_encode
+   fun:lzma_compress
+   fun:compress_lib_test
+   fun:compress_cfg
+   fun:knet_handle_compress
+   fun:test
+}
+{
    lzma internal stuff (Ubuntu 17.10 i386)
    Memcheck:Cond
    obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
@@ -492,6 +508,22 @@
    fun:_parse_recv_from_sock
    fun:_handle_send_to_links
    fun:_handle_send_to_links_thread
+}
+{
+   lzma internal stuff (Ubuntu 17.10 i386)
+   Memcheck:Cond
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/i386-linux-gnu/liblzma.so.5.2.2
+   fun:lzma_stream_buffer_encode
+   fun:lzma_easy_buffer_encode
+   fun:lzma_compress
+   fun:compress_lib_test
+   fun:compress_cfg
+   fun:knet_handle_compress
 }
 {
    nss internal stuff (FreeBSD 11.1)

--- a/configure.ac
+++ b/configure.ac
@@ -507,4 +507,17 @@ AC_CONFIG_FILES([
 		poc-code/access-list/Makefile
 		])
 
+if test "x$VERSION" = "xUNKNOWN"; then
+	AC_MSG_ERROR([m4_text_wrap([
+  configure was unable to determine the source tree's current version. This
+  generally happens when using git archive (or the github download button)
+  generated tarball/zip file. In order to workaround this issue, either use git
+  clone https://github.com/kronosnet/kronosnet.git or use an official release
+  tarball, available at https://kronosnet.org/releases/.  Alternatively you
+  can add a compatible version in a .tarball-version file at the top of the
+  source tree, wipe your autom4te.cache dir and generated configure, and rerun
+  autogen.sh.
+  ], [  ], [   ], [76])])
+fi
+
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -469,8 +469,8 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 	[AC_MSG_RESULT([yes])],
 	[AC_MSG_RESULT([no])
 	 AC_MSG_CHECKING([for source epoch in source_epoch file])
-	 AS_IF([test -e source_epoch],
-		[read SOURCE_EPOCH <source_epoch
+	 AS_IF([test -e "$srcdir/source_epoch"],
+		[read SOURCE_EPOCH <"$srcdir/source_epoch"
 		 AC_MSG_RESULT([yes])],
 		[AC_MSG_RESULT([no])
 		 AC_MSG_CHECKING([for source epoch baked in by gitattributes export-subst])

--- a/configure.ac
+++ b/configure.ac
@@ -454,6 +454,34 @@ done
 
 AC_SUBST([AM_CFLAGS],["$OPT_CFLAGS $GDB_FLAGS $EXTRA_WARNINGS"])
 
+AC_ARG_VAR([SOURCE_EPOCH],[last modification date of the source])
+AC_MSG_NOTICE([trying to determine source epoch])
+AC_MSG_CHECKING([for source epoch in \$SOURCE_EPOCH])
+AS_IF([test -n "$SOURCE_EPOCH"],
+	[AC_MSG_RESULT([yes])],
+	[AC_MSG_RESULT([no])
+	 AC_MSG_CHECKING([for source epoch in source_epoch file])
+	 AS_IF([test -e source_epoch],
+		[read SOURCE_EPOCH <source_epoch
+		 AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([no])
+		 AC_MSG_CHECKING([for source epoch baked in by gitattributes export-subst])
+		 SOURCE_EPOCH='$Format:%at$' # template for rewriting by git-archive
+		 AS_CASE([$SOURCE_EPOCH],
+			[?Format:*], # was not rewritten
+				[AC_MSG_RESULT([no])
+				 AC_MSG_CHECKING([whether git log can provide a source epoch])
+				 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
+				 SOURCE_EPOCH=$(git -C "$srcdir" log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
+				 AS_IF([test -n "$SOURCE_EPOCH"],
+					[AC_MSG_RESULT([yes])],
+					[AC_MSG_RESULT([no, using current time and breaking reproducibility])
+					 SOURCE_EPOCH=$(date +%s)])],
+			[AC_MSG_RESULT([yes])]
+		 )])
+	])
+AC_MSG_NOTICE([using source epoch $(date --iso-8601=s --utc -d @$SOURCE_EPOCH)])
+
 AC_CONFIG_FILES([
 		Makefile
 		init/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -478,13 +478,18 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 		 AS_CASE([$SOURCE_EPOCH],
 			[?Format:*], # was not rewritten
 				[AC_MSG_RESULT([no])
-				 AC_MSG_CHECKING([whether git log can provide a source epoch])
-				 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
-				 SOURCE_EPOCH=$(cd "$srcdir" && git log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
-				 AS_IF([test -n "$SOURCE_EPOCH"],
-					[AC_MSG_RESULT([yes])],
-					[AC_MSG_RESULT([no, using current time and breaking reproducibility])
-					 SOURCE_EPOCH=$(date +%s)])],
+				 AC_MSG_CHECKING([for source epoch in \$SOURCE_DATE_EPOCH])
+				 AS_IF([test "x$SOURCE_DATE_EPOCH" != x],
+					[SOURCE_EPOCH="$SOURCE_DATE_EPOCH"
+					 AC_MSG_RESULT([yes])],
+					[AC_MSG_RESULT([no])
+					 AC_MSG_CHECKING([whether git log can provide a source epoch])
+					 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
+					 SOURCE_EPOCH=$(cd "$srcdir" && git log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
+					 AS_IF([test -n "$SOURCE_EPOCH"],
+						[AC_MSG_RESULT([yes])],
+						[AC_MSG_RESULT([no, using current time and breaking reproducibility])
+						 SOURCE_EPOCH=$(date +%s)])])],
 			[AC_MSG_RESULT([yes])]
 		 )])
 	])

--- a/configure.ac
+++ b/configure.ac
@@ -454,6 +454,14 @@ done
 
 AC_SUBST([AM_CFLAGS],["$OPT_CFLAGS $GDB_FLAGS $EXTRA_WARNINGS"])
 
+AX_PROG_DATE
+AS_IF([test "$ax_cv_prog_date_gnu_date:$ax_cv_prog_date_gnu_utc" = yes:yes],
+	[UTC_DATE_AT="date -u -d@"],
+	[AS_IF([test "x$ax_cv_prog_date_bsd_date" = xyes],
+		[UTC_DATE_AT="date -u -r"],
+		[AC_MSG_ERROR([date utility unable to convert epoch to UTC])])])
+AC_SUBST([UTC_DATE_AT])
+
 AC_ARG_VAR([SOURCE_EPOCH],[last modification date of the source])
 AC_MSG_NOTICE([trying to determine source epoch])
 AC_MSG_CHECKING([for source epoch in \$SOURCE_EPOCH])
@@ -480,7 +488,7 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 			[AC_MSG_RESULT([yes])]
 		 )])
 	])
-AC_MSG_NOTICE([using source epoch $(date --iso-8601=s --utc -d @$SOURCE_EPOCH)])
+AC_MSG_NOTICE([using source epoch $($UTC_DATE_AT$SOURCE_EPOCH +'%F %T %Z')])
 
 AC_CONFIG_FILES([
 		Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -480,7 +480,7 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 				[AC_MSG_RESULT([no])
 				 AC_MSG_CHECKING([whether git log can provide a source epoch])
 				 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
-				 SOURCE_EPOCH=$(git -C "$srcdir" log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
+				 SOURCE_EPOCH=$(cd "$srcdir" && git log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
 				 AS_IF([test -n "$SOURCE_EPOCH"],
 					[AC_MSG_RESULT([yes])],
 					[AC_MSG_RESULT([no, using current time and breaking reproducibility])

--- a/libknet/compress.c
+++ b/libknet/compress.c
@@ -193,6 +193,7 @@ static int compress_lib_test(knet_handle_t knet_h)
 	unsigned char src[KNET_DATABUFSIZE];
 	unsigned char dst[KNET_DATABUFSIZE_COMPRESS];
 	ssize_t dst_comp_len = KNET_DATABUFSIZE_COMPRESS, dst_decomp_len = KNET_DATABUFSIZE;
+	unsigned int i;
 
 	memset(src, 0, KNET_DATABUFSIZE);
 	memset(dst, 0, KNET_DATABUFSIZE_COMPRESS);
@@ -214,6 +215,14 @@ static int compress_lib_test(knet_handle_t knet_h)
 		log_err(knet_h, KNET_SUB_COMPRESS, "Unable to decompress test buffer. Please check your compression settings: %s", strerror(savederrno));
 		errno = savederrno;
 		return -1;
+	}
+
+	for (i = 0; i < KNET_DATABUFSIZE; i++) {
+		if (src[i] != 0) {
+			log_err(knet_h, KNET_SUB_COMPRESS, "Decompressed buffer contains incorrect data");
+			errno = EINVAL;
+			return -1;
+		}
 	}
 
 	return 0;

--- a/libknet/compress_bzip2.c
+++ b/libknet/compress_bzip2.c
@@ -15,18 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int bzip2_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if ((compress_level < 1) || (compress_level > 9)) {
-                log_err(knet_h, KNET_SUB_BZIP2COMP, "bzip2 unsupported compression level %d (accepted values from 1 to 9)", compress_level);
-		errno = EINVAL;
-		return -1;
-	}
-	return 0;
-}
-
 static int bzip2_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -120,7 +108,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	bzip2_val_level,
+	NULL,
 	bzip2_compress,
 	bzip2_decompress
 };

--- a/libknet/compress_lz4.c
+++ b/libknet/compress_lz4.c
@@ -15,17 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int lz4_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if (compress_level <= 0) {
-		log_info(knet_h, KNET_SUB_LZ4COMP, "lz4 acceleration level 0 (or negatives) are automatically remapped to 1");
-	}
-
-	return 0;
-}
-
 static int lz4_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -96,7 +85,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	lz4_val_level,
+	NULL,
 	lz4_compress,
 	lz4_decompress
 };

--- a/libknet/compress_lz4hc.c
+++ b/libknet/compress_lz4hc.c
@@ -32,27 +32,6 @@
 #define KNET_LZ4HC_MAX 16
 #endif
 
-static int lz4hc_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if (compress_level < 1) {
-		log_err(knet_h, KNET_SUB_LZ4HCCOMP, "lz4hc supports only 1+ values for compression level");
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (compress_level < 4) {
-		log_info(knet_h, KNET_SUB_LZ4HCCOMP, "lz4hc recommends 4+ compression level for better results");
-	}
-
-	if (compress_level > KNET_LZ4HC_MAX) {
-		log_warn(knet_h, KNET_SUB_LZ4HCCOMP, "lz4hc installed on this system supports up to compression level %d. Higher values behaves as %d", KNET_LZ4HC_MAX, KNET_LZ4HC_MAX);
-	}
-
-	return 0;
-}
-
 static int lz4hc_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -117,7 +96,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	lz4hc_val_level,
+	NULL,
 	lz4hc_compress,
 	lz4_decompress
 };

--- a/libknet/compress_lzma.c
+++ b/libknet/compress_lzma.c
@@ -15,19 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int lzma_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if ((compress_level < 0) || (compress_level > 9)) {
-                log_err(knet_h, KNET_SUB_LZMACOMP, "lzma unsupported compression preset %d (accepted values from 0 to 9)", compress_level);
-		errno = EINVAL;
-		return -1;
-	}
-
-	return 0;
-}
-
 static int lzma_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -132,7 +119,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	lzma_val_level,
+	NULL,
 	lzma_compress,
 	lzma_decompress
 };

--- a/libknet/compress_model.h
+++ b/libknet/compress_model.h
@@ -48,8 +48,6 @@ typedef struct {
 	 */
 
 	/*
-	 * required functions
-	 *
 	 * val_level is called upon compress configuration changes
 	 * to make sure that the requested compress_level is valid
 	 * within the context of a given module.
@@ -58,6 +56,8 @@ typedef struct {
 			 int compress_level);
 
 	/*
+	 * required functions
+	 *
 	 * hopefully those 2 don't require any explanation....
 	 */
 	int (*compress)	(knet_handle_t knet_h,

--- a/libknet/compress_zlib.c
+++ b/libknet/compress_zlib.c
@@ -15,25 +15,6 @@
 #include "logging.h"
 #include "compress_model.h"
 
-static int zlib_val_level(
-	knet_handle_t knet_h,
-	int compress_level)
-{
-	if (compress_level < 0) {
-		log_err(knet_h, KNET_SUB_ZLIBCOMP, "zlib does not support negative compression level %d",
-			 compress_level);
-		return -1;
-	}
-	if (compress_level > 9) {
-		log_err(knet_h, KNET_SUB_ZLIBCOMP, "zlib does not support compression level higher than 9");
-		return -1;
-	}
-	if (compress_level == 0) {
-		log_warn(knet_h, KNET_SUB_ZLIBCOMP, "zlib compress level 0 does NOT perform any compression");
-	}
-	return 0;
-}
-
 static int zlib_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -130,7 +111,7 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	NULL,
-	zlib_val_level,
+	NULL,
 	zlib_compress,
 	zlib_decompress
 };

--- a/libknet/tests/api_knet_handle_compress.c
+++ b/libknet/tests/api_knet_handle_compress.c
@@ -81,14 +81,14 @@ static void test(void)
 
 	flush_logs(logfds[0], stdout);
 
-	printf("Test knet_handle_compress with zlib compress and negative level\n");
+	printf("Test knet_handle_compress with zlib compress and negative level (-2)\n");
 
 	memset(&knet_handle_compress_cfg, 0, sizeof(struct knet_handle_compress_cfg));
 	strncpy(knet_handle_compress_cfg.compress_model, "zlib", sizeof(knet_handle_compress_cfg.compress_model) - 1);
-	knet_handle_compress_cfg.compress_level = -1;
+	knet_handle_compress_cfg.compress_level = -2;
 
 	if ((!knet_handle_compress(knet_h, &knet_handle_compress_cfg)) || (errno != EINVAL)) {
-		printf("knet_handle_compress accepted invalid (-1) compress level for zlib\n");
+		printf("knet_handle_compress accepted invalid (-2) compress level for zlib\n");
 		knet_handle_free(knet_h);
 		flush_logs(logfds[0], stdout);
 		close_logpipes(logfds);

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -452,6 +452,10 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 
 				/* check if we are dst for this packet */
 				if (!bcast) {
+					if (dst_host_ids_entries > KNET_MAX_HOST) {
+						log_debug(knet_h, KNET_SUB_RX, "dst_host_filter_fn returned too many destinations");
+						return;
+					}
 					for (host_idx = 0; host_idx < dst_host_ids_entries; host_idx++) {
 						if (dst_host_ids[host_idx] == knet_h->host_id) {
 							found = 1;

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -195,6 +195,14 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 					err = -1;
 					goto out_unlock;
 				}
+
+				if ((!bcast) &&
+				    (dst_host_ids_entries_temp > KNET_MAX_HOST)) {
+					log_debug(knet_h, KNET_SUB_TX, "dst_host_filter_fn returned too many destinations");
+					savederrno = EINVAL;
+					err = -1;
+					goto out_unlock;
+				}
 			}
 
 			/* Send to localhost if appropriate and enabled */

--- a/m4/ax_prog_date.m4
+++ b/m4/ax_prog_date.m4
@@ -1,0 +1,137 @@
+# ===========================================================================
+#       https://www.gnu.org/software/autoconf-archive/ax_prog_date.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_DATE()
+#
+# DESCRIPTION
+#
+#   This macro tries to determine the type of the date (1) command and some
+#   of its non-standard capabilities.
+#
+#   The type is determined as follow:
+#
+#     * If the version string contains "GNU", then:
+#       - The variable ax_cv_prog_date_gnu is set to "yes".
+#       - The variable ax_cv_prog_date_type is set to "gnu".
+#
+#     * If date supports the "-v 1d" option, then:
+#       - The variable ax_cv_prog_date_bsd is set to "yes".
+#       - The variable ax_cv_prog_date_type is set to "bsd".
+#
+#     * If both previous checks fail, then:
+#       - The variable ax_cv_prog_date_type is set to "unknown".
+#
+#   The following capabilities of GNU date are checked:
+#
+#     * If date supports the --date arg option, then:
+#       - The variable ax_cv_prog_date_gnu_date is set to "yes".
+#
+#     * If date supports the --utc arg option, then:
+#       - The variable ax_cv_prog_date_gnu_utc is set to "yes".
+#
+#   The following capabilities of BSD date are checked:
+#
+#     * If date supports the -v 1d  option, then:
+#       - The variable ax_cv_prog_date_bsd_adjust is set to "yes".
+#
+#     * If date supports the -r arg option, then:
+#       - The variable ax_cv_prog_date_bsd_date is set to "yes".
+#
+#   All the aforementioned variables are set to "no" before a check is
+#   performed.
+#
+# LICENSE
+#
+#   Copyright (c) 2017 Enrico M. Crisostomo <enrico.m.crisostomo@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_PROG_DATE], [dnl
+  AC_CACHE_CHECK([for GNU date], [ax_cv_prog_date_gnu], [
+    ax_cv_prog_date_gnu=no
+    if date --version 2>/dev/null | head -1 | grep -q GNU
+    then
+      ax_cv_prog_date_gnu=yes
+    fi
+  ])
+  AC_CACHE_CHECK([for BSD date], [ax_cv_prog_date_bsd], [
+    ax_cv_prog_date_bsd=no
+    if date -v 1d > /dev/null 2>&1
+    then
+      ax_cv_prog_date_bsd=yes
+    fi
+  ])
+  AC_CACHE_CHECK([for date type], [ax_cv_prog_date_type], [
+    ax_cv_prog_date_type=unknown
+    if test "x${ax_cv_prog_date_gnu}" = "xyes"
+    then
+      ax_cv_prog_date_type=gnu
+    elif test "x${ax_cv_prog_date_bsd}" = "xyes"
+    then
+      ax_cv_prog_date_type=bsd
+    fi
+  ])
+  AS_VAR_IF([ax_cv_prog_date_gnu], [yes], [
+    AC_CACHE_CHECK([whether GNU date supports --date], [ax_cv_prog_date_gnu_date], [
+      ax_cv_prog_date_gnu_date=no
+      if date --date=@1512031231 > /dev/null 2>&1
+      then
+        ax_cv_prog_date_gnu_date=yes
+      fi
+    ])
+    AC_CACHE_CHECK([whether GNU date supports --utc], [ax_cv_prog_date_gnu_utc], [
+      ax_cv_prog_date_gnu_utc=no
+      if date --utc > /dev/null 2>&1
+      then
+        ax_cv_prog_date_gnu_utc=yes
+      fi
+    ])
+  ])
+  AS_VAR_IF([ax_cv_prog_date_bsd], [yes], [
+    AC_CACHE_CHECK([whether BSD date supports -r], [ax_cv_prog_date_bsd_date], [
+      ax_cv_prog_date_bsd_date=no
+      if date -r 1512031231 > /dev/null 2>&1
+      then
+        ax_cv_prog_date_bsd_date=yes
+      fi
+    ])
+  ])
+    AS_VAR_IF([ax_cv_prog_date_bsd], [yes], [
+    AC_CACHE_CHECK([whether BSD date supports -v], [ax_cv_prog_date_bsd_adjust], [
+      ax_cv_prog_date_bsd_adjust=no
+      if date -v 1d > /dev/null 2>&1
+      then
+        ax_cv_prog_date_bsd_adjust=yes
+      fi
+    ])
+  ])
+])dnl AX_PROG_DATE

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -101,7 +101,8 @@ $(MANS): doxyfile-knet.stamp
 
 doxyfile-knet.stamp: $(builddir)/doxyxml Doxyfile-knet $(top_srcdir)/libknet/libknet.h
 	$(DOXYGEN) Doxyfile-knet
-	$(builddir)/doxyxml -m -P -o $(builddir) -s 3 -p @PACKAGE_NAME@ -H "Kronosnet Programmer's Manual" -d $(builddir)/xml-knet/ libknet_8h.xml
+	$(builddir)/doxyxml -m -P -o $(builddir) -s 3 -p @PACKAGE_NAME@ -H "Kronosnet Programmer's Manual" \
+		$$(date --utc -d "@$(SOURCE_EPOCH)" +"-D %F -Y %Y") -d $(builddir)/xml-knet/ libknet_8h.xml
 	touch doxyfile-knet.stamp
 
 endif

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -102,7 +102,7 @@ $(MANS): doxyfile-knet.stamp
 doxyfile-knet.stamp: $(builddir)/doxyxml Doxyfile-knet $(top_srcdir)/libknet/libknet.h
 	$(DOXYGEN) Doxyfile-knet
 	$(builddir)/doxyxml -m -P -o $(builddir) -s 3 -p @PACKAGE_NAME@ -H "Kronosnet Programmer's Manual" \
-		$$(date --utc -d "@$(SOURCE_EPOCH)" +"-D %F -Y %Y") -d $(builddir)/xml-knet/ libknet_8h.xml
+		$$($(UTC_DATE_AT)$(SOURCE_EPOCH) +"-D %F -Y %Y") -d $(builddir)/xml-knet/ libknet_8h.xml
 	touch doxyfile-knet.stamp
 
 endif


### PR DESCRIPTION
libknet cannot guarantee that the dst_host_filter is sane nor that it cannot
be exploited to return garbage to knet.

there is an infinitesimal possibility that, if the plugin returns total crap,
knet could crash by trying to access out-of-bound memory.

Prevent that by adding specific checks both in TX/RX.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>