### PR TITLE
Source epoch and version check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+configure.ac export-subst

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ distclean-local:
 
 $(SPEC): $(SPEC).in .version config.status
 	rm -f $@-t $@
-	date="`LC_ALL=C date "+%a %b %d %Y"`" && \
+	date="`LC_ALL=C date -d "@$(SOURCE_EPOCH)" "+%a %b %d %Y"`" && \
 	if [ -f $(abs_srcdir)/.tarball-version ]; then \
 		gitver="`cat $(abs_srcdir)/.tarball-version`" && \
 		rpmver=$$gitver && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ distclean-local:
 
 $(SPEC): $(SPEC).in .version config.status
 	rm -f $@-t $@
-	date="`LC_ALL=C date -d "@$(SOURCE_EPOCH)" "+%a %b %d %Y"`" && \
+	date="`LC_ALL=C $(UTC_DATE_AT)$(SOURCE_EPOCH) "+%a %b %d %Y"`" && \
 	if [ -f $(abs_srcdir)/.tarball-version ]; then \
 		gitver="`cat $(abs_srcdir)/.tarball-version`" && \
 		rpmver=$$gitver && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ BUILT_SOURCES	= .version
 
 dist-hook: gen-ChangeLog
 	echo $(VERSION) > $(distdir)/.tarball-version
+	echo $(SOURCE_EPOCH) > $(distdir)/source_epoch
 
 gen_start_date = 2000-01-01
 .PHONY: gen-ChangeLog

--- a/configure.ac
+++ b/configure.ac
@@ -507,4 +507,17 @@ AC_CONFIG_FILES([
 		poc-code/access-list/Makefile
 		])
 
+if test "x$VERSION" = "xUNKNOWN"; then
+	AC_MSG_ERROR([m4_text_wrap([
+  configure was unable to determine the source tree's current version. This
+  generally happens when using git archive (or the github download button)
+  generated tarball/zip file. In order to workaround this issue, either use git
+  clone https://github.com/kronosnet/kronosnet.git or use an official release
+  tarball, available at https://kronosnet.org/releases/.  Alternatively you
+  can add a compatible version in a .tarball-version file at the top of the
+  source tree, wipe your autom4te.cache dir and generated configure, and rerun
+  autogen.sh.
+  ], [  ], [   ], [76])])
+fi
+
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -469,8 +469,8 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 	[AC_MSG_RESULT([yes])],
 	[AC_MSG_RESULT([no])
 	 AC_MSG_CHECKING([for source epoch in source_epoch file])
-	 AS_IF([test -e source_epoch],
-		[read SOURCE_EPOCH <source_epoch
+	 AS_IF([test -e "$srcdir/source_epoch"],
+		[read SOURCE_EPOCH <"$srcdir/source_epoch"
 		 AC_MSG_RESULT([yes])],
 		[AC_MSG_RESULT([no])
 		 AC_MSG_CHECKING([for source epoch baked in by gitattributes export-subst])

--- a/configure.ac
+++ b/configure.ac
@@ -454,6 +454,34 @@ done
 
 AC_SUBST([AM_CFLAGS],["$OPT_CFLAGS $GDB_FLAGS $EXTRA_WARNINGS"])
 
+AC_ARG_VAR([SOURCE_EPOCH],[last modification date of the source])
+AC_MSG_NOTICE([trying to determine source epoch])
+AC_MSG_CHECKING([for source epoch in \$SOURCE_EPOCH])
+AS_IF([test -n "$SOURCE_EPOCH"],
+	[AC_MSG_RESULT([yes])],
+	[AC_MSG_RESULT([no])
+	 AC_MSG_CHECKING([for source epoch in source_epoch file])
+	 AS_IF([test -e source_epoch],
+		[read SOURCE_EPOCH <source_epoch
+		 AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([no])
+		 AC_MSG_CHECKING([for source epoch baked in by gitattributes export-subst])
+		 SOURCE_EPOCH='$Format:%at$' # template for rewriting by git-archive
+		 AS_CASE([$SOURCE_EPOCH],
+			[?Format:*], # was not rewritten
+				[AC_MSG_RESULT([no])
+				 AC_MSG_CHECKING([whether git log can provide a source epoch])
+				 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
+				 SOURCE_EPOCH=$(git -C "$srcdir" log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
+				 AS_IF([test -n "$SOURCE_EPOCH"],
+					[AC_MSG_RESULT([yes])],
+					[AC_MSG_RESULT([no, using current time and breaking reproducibility])
+					 SOURCE_EPOCH=$(date +%s)])],
+			[AC_MSG_RESULT([yes])]
+		 )])
+	])
+AC_MSG_NOTICE([using source epoch $(date --iso-8601=s --utc -d @$SOURCE_EPOCH)])
+
 AC_CONFIG_FILES([
 		Makefile
 		init/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -478,13 +478,18 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 		 AS_CASE([$SOURCE_EPOCH],
 			[?Format:*], # was not rewritten
 				[AC_MSG_RESULT([no])
-				 AC_MSG_CHECKING([whether git log can provide a source epoch])
-				 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
-				 SOURCE_EPOCH=$(cd "$srcdir" && git log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
-				 AS_IF([test -n "$SOURCE_EPOCH"],
-					[AC_MSG_RESULT([yes])],
-					[AC_MSG_RESULT([no, using current time and breaking reproducibility])
-					 SOURCE_EPOCH=$(date +%s)])],
+				 AC_MSG_CHECKING([for source epoch in \$SOURCE_DATE_EPOCH])
+				 AS_IF([test "x$SOURCE_DATE_EPOCH" != x],
+					[SOURCE_EPOCH="$SOURCE_DATE_EPOCH"
+					 AC_MSG_RESULT([yes])],
+					[AC_MSG_RESULT([no])
+					 AC_MSG_CHECKING([whether git log can provide a source epoch])
+					 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
+					 SOURCE_EPOCH=$(cd "$srcdir" && git log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
+					 AS_IF([test -n "$SOURCE_EPOCH"],
+						[AC_MSG_RESULT([yes])],
+						[AC_MSG_RESULT([no, using current time and breaking reproducibility])
+						 SOURCE_EPOCH=$(date +%s)])])],
 			[AC_MSG_RESULT([yes])]
 		 )])
 	])

--- a/configure.ac
+++ b/configure.ac
@@ -454,6 +454,14 @@ done
 
 AC_SUBST([AM_CFLAGS],["$OPT_CFLAGS $GDB_FLAGS $EXTRA_WARNINGS"])
 
+AX_PROG_DATE
+AS_IF([test "$ax_cv_prog_date_gnu_date:$ax_cv_prog_date_gnu_utc" = yes:yes],
+	[UTC_DATE_AT="date -u -d@"],
+	[AS_IF([test "x$ax_cv_prog_date_bsd_date" = xyes],
+		[UTC_DATE_AT="date -u -r"],
+		[AC_MSG_ERROR([date utility unable to convert epoch to UTC])])])
+AC_SUBST([UTC_DATE_AT])
+
 AC_ARG_VAR([SOURCE_EPOCH],[last modification date of the source])
 AC_MSG_NOTICE([trying to determine source epoch])
 AC_MSG_CHECKING([for source epoch in \$SOURCE_EPOCH])
@@ -480,7 +488,7 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 			[AC_MSG_RESULT([yes])]
 		 )])
 	])
-AC_MSG_NOTICE([using source epoch $(date --iso-8601=s --utc -d @$SOURCE_EPOCH)])
+AC_MSG_NOTICE([using source epoch $($UTC_DATE_AT$SOURCE_EPOCH +'%F %T %Z')])
 
 AC_CONFIG_FILES([
 		Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -480,7 +480,7 @@ AS_IF([test -n "$SOURCE_EPOCH"],
 				[AC_MSG_RESULT([no])
 				 AC_MSG_CHECKING([whether git log can provide a source epoch])
 				 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
-				 SOURCE_EPOCH=$(git -C "$srcdir" log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
+				 SOURCE_EPOCH=$(cd "$srcdir" && git log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
 				 AS_IF([test -n "$SOURCE_EPOCH"],
 					[AC_MSG_RESULT([yes])],
 					[AC_MSG_RESULT([no, using current time and breaking reproducibility])

--- a/m4/ax_prog_date.m4
+++ b/m4/ax_prog_date.m4
@@ -1,0 +1,137 @@
+# ===========================================================================
+#       https://www.gnu.org/software/autoconf-archive/ax_prog_date.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_DATE()
+#
+# DESCRIPTION
+#
+#   This macro tries to determine the type of the date (1) command and some
+#   of its non-standard capabilities.
+#
+#   The type is determined as follow:
+#
+#     * If the version string contains "GNU", then:
+#       - The variable ax_cv_prog_date_gnu is set to "yes".
+#       - The variable ax_cv_prog_date_type is set to "gnu".
+#
+#     * If date supports the "-v 1d" option, then:
+#       - The variable ax_cv_prog_date_bsd is set to "yes".
+#       - The variable ax_cv_prog_date_type is set to "bsd".
+#
+#     * If both previous checks fail, then:
+#       - The variable ax_cv_prog_date_type is set to "unknown".
+#
+#   The following capabilities of GNU date are checked:
+#
+#     * If date supports the --date arg option, then:
+#       - The variable ax_cv_prog_date_gnu_date is set to "yes".
+#
+#     * If date supports the --utc arg option, then:
+#       - The variable ax_cv_prog_date_gnu_utc is set to "yes".
+#
+#   The following capabilities of BSD date are checked:
+#
+#     * If date supports the -v 1d  option, then:
+#       - The variable ax_cv_prog_date_bsd_adjust is set to "yes".
+#
+#     * If date supports the -r arg option, then:
+#       - The variable ax_cv_prog_date_bsd_date is set to "yes".
+#
+#   All the aforementioned variables are set to "no" before a check is
+#   performed.
+#
+# LICENSE
+#
+#   Copyright (c) 2017 Enrico M. Crisostomo <enrico.m.crisostomo@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_PROG_DATE], [dnl
+  AC_CACHE_CHECK([for GNU date], [ax_cv_prog_date_gnu], [
+    ax_cv_prog_date_gnu=no
+    if date --version 2>/dev/null | head -1 | grep -q GNU
+    then
+      ax_cv_prog_date_gnu=yes
+    fi
+  ])
+  AC_CACHE_CHECK([for BSD date], [ax_cv_prog_date_bsd], [
+    ax_cv_prog_date_bsd=no
+    if date -v 1d > /dev/null 2>&1
+    then
+      ax_cv_prog_date_bsd=yes
+    fi
+  ])
+  AC_CACHE_CHECK([for date type], [ax_cv_prog_date_type], [
+    ax_cv_prog_date_type=unknown
+    if test "x${ax_cv_prog_date_gnu}" = "xyes"
+    then
+      ax_cv_prog_date_type=gnu
+    elif test "x${ax_cv_prog_date_bsd}" = "xyes"
+    then
+      ax_cv_prog_date_type=bsd
+    fi
+  ])
+  AS_VAR_IF([ax_cv_prog_date_gnu], [yes], [
+    AC_CACHE_CHECK([whether GNU date supports --date], [ax_cv_prog_date_gnu_date], [
+      ax_cv_prog_date_gnu_date=no
+      if date --date=@1512031231 > /dev/null 2>&1
+      then
+        ax_cv_prog_date_gnu_date=yes
+      fi
+    ])
+    AC_CACHE_CHECK([whether GNU date supports --utc], [ax_cv_prog_date_gnu_utc], [
+      ax_cv_prog_date_gnu_utc=no
+      if date --utc > /dev/null 2>&1
+      then
+        ax_cv_prog_date_gnu_utc=yes
+      fi
+    ])
+  ])
+  AS_VAR_IF([ax_cv_prog_date_bsd], [yes], [
+    AC_CACHE_CHECK([whether BSD date supports -r], [ax_cv_prog_date_bsd_date], [
+      ax_cv_prog_date_bsd_date=no
+      if date -r 1512031231 > /dev/null 2>&1
+      then
+        ax_cv_prog_date_bsd_date=yes
+      fi
+    ])
+  ])
+    AS_VAR_IF([ax_cv_prog_date_bsd], [yes], [
+    AC_CACHE_CHECK([whether BSD date supports -v], [ax_cv_prog_date_bsd_adjust], [
+      ax_cv_prog_date_bsd_adjust=no
+      if date -v 1d > /dev/null 2>&1
+      then
+        ax_cv_prog_date_bsd_adjust=yes
+      fi
+    ])
+  ])
+])dnl AX_PROG_DATE

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -101,7 +101,8 @@ $(MANS): doxyfile-knet.stamp
 
 doxyfile-knet.stamp: $(builddir)/doxyxml Doxyfile-knet $(top_srcdir)/libknet/libknet.h
 	$(DOXYGEN) Doxyfile-knet
-	$(builddir)/doxyxml -m -P -o $(builddir) -s 3 -p @PACKAGE_NAME@ -H "Kronosnet Programmer's Manual" -d $(builddir)/xml-knet/ libknet_8h.xml
+	$(builddir)/doxyxml -m -P -o $(builddir) -s 3 -p @PACKAGE_NAME@ -H "Kronosnet Programmer's Manual" \
+		$$(date --utc -d "@$(SOURCE_EPOCH)" +"-D %F -Y %Y") -d $(builddir)/xml-knet/ libknet_8h.xml
 	touch doxyfile-knet.stamp
 
 endif

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -102,7 +102,7 @@ $(MANS): doxyfile-knet.stamp
 doxyfile-knet.stamp: $(builddir)/doxyxml Doxyfile-knet $(top_srcdir)/libknet/libknet.h
 	$(DOXYGEN) Doxyfile-knet
 	$(builddir)/doxyxml -m -P -o $(builddir) -s 3 -p @PACKAGE_NAME@ -H "Kronosnet Programmer's Manual" \
-		$$(date --utc -d "@$(SOURCE_EPOCH)" +"-D %F -Y %Y") -d $(builddir)/xml-knet/ libknet_8h.xml
+		$$($(UTC_DATE_AT)$(SOURCE_EPOCH) +"-D %F -Y %Y") -d $(builddir)/xml-knet/ libknet_8h.xml
 	touch doxyfile-knet.stamp
 
 endif


### PR DESCRIPTION
Hi,

I addressed the immediate concerns and also pulled in the version check from #142 with line wrapping added. Before considering merging this, there are at least two issues to settle:

1. Commit date or author date? First is the actual date when the last commit was created technically (emergence of the commit hash, so sorts properly), second is the original creation date of the last commit (visible in default git output). If the release process starts from an administrative merge commit (as usual), this won't make much practical difference in the tarballs.
2. Check for the `date` utility and accommodate (as now) or make `doxyxml` accept an Epoch value and do the conversion internally like in #141? The latter disregards the spec file date, but that changelog entry seems somewhat neglected anyway.

Once the above are decided, I can rebase (and possibly squash a little) this series.

Regards,
Feri.