### PR TITLE
[crypto] NSS_NoDB_Init: the parameter is reserved, must be NULL

### DIFF
--- a/libknet/crypto_nss.c
+++ b/libknet/crypto_nss.c
@@ -590,7 +590,7 @@ static int init_nss(knet_handle_t knet_h)
 	}
 
 	if (!nss_db_is_init) {
-		if (NSS_NoDB_Init(".") != SECSuccess) {
+		if (NSS_NoDB_Init(NULL) != SECSuccess) {
 			log_err(knet_h, KNET_SUB_NSSCRYPTO, "NSS DB initialization failed (err %d): %s",
 				PR_GetError(), PR_ErrorToString(PR_GetError(), PR_LANGUAGE_I_DEFAULT));
 			errno = EAGAIN;


### PR DESCRIPTION
Thanks to Feri for spotting it in corosync

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>