### PR TITLE
[tests] add another lzma exception

### DIFF
--- a/build-aux/knet_valgrind_memcheck.supp
+++ b/build-aux/knet_valgrind_memcheck.supp
@@ -460,6 +460,19 @@
    fun:start_thread
 }
 {
+   lzma internal stuff (Debian Experimental)
+   Memcheck:Cond
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2
+   fun:lzma_block_buffer_encode
+   fun:lzma_stream_buffer_encode
+   fun:lzma_easy_buffer_encode
+   obj:*/libknet/.libs/compress_lzma.so
+   obj:*
+}
+{
    lzma internal stuff (Debian / Ubuntu)
    Memcheck:Cond
    obj:/lib/x86_64-linux-gnu/liblzma.so.5.2.2


### PR DESCRIPTION
spotted on Debian Experimental, the latest toolchain appears to add
full path to objects and valgrind would generate an error.

add a generic catch-all path exception.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>