### PR TITLE
Use git archive stored version tag

### DIFF
--- a/.gitarchivever
+++ b/.gitarchivever
@@ -1,0 +1,1 @@
+ref names:$Format:%d$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 configure.ac export-subst
+.gitarchivever export-subst

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,7 @@ $(SPEC): $(SPEC).in .version config.status
 		alphatag="" && \
 		dirty="" && \
 		numcomm="0"; \
-	else \
+	elif [ "`git log -1 --pretty=format:x . 2>&1`" = "x" ]; then \
 		gitver="`GIT_DIR=$(abs_srcdir)/.git git describe --abbrev=4 --match='v*' HEAD 2>/dev/null`" && \
 		rpmver=`echo $$gitver | sed -e "s/^v//" -e "s/-.*//g"` && \
 		alphatag=`echo $$gitver | sed -e "s/.*-//" -e "s/^g//"` && \
@@ -72,6 +72,12 @@ $(SPEC): $(SPEC).in .version config.status
 		cd $(abs_srcdir) && \
 		git update-index --refresh > /dev/null 2>&1 || true && \
 		dirty=`git diff-index --name-only HEAD 2>/dev/null` && cd - 2>/dev/null; \
+	else \
+		gitver="`cd $(abs_srcdir); build-aux/git-version-gen .tarball-version .gitarchivever`" && \
+		rpmver=$$gitver && \
+		alphatag="" && \
+		dirty="" && \
+		numcomm="0"; \
 	fi && \
 	if [ -n "$$dirty" ]; then dirty="dirty"; else dirty=""; fi && \
 	if [ "$$numcomm" = "0" ]; then \

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -223,6 +223,14 @@ else
     v=$fallback
 fi
 
+if test "x$fallback" = x -a "$v" = "UNKNOWN"
+then
+  echo "$0: ERROR: Can't find valid version. Please use valid git repository," \
+    "released tarball or version tagged archive" 1>&2
+
+  exit 1
+fi
+
 v=`echo "$v" |sed "s/^$prefix//"`
 
 # Test whether to append the "-dirty" suffix only if the version

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -169,8 +169,8 @@ then
 # directory, and "git describe" output looks sensible, use that to
 # derive a version string.
 elif test "`git log -1 --pretty=format:x . 2>&1`" = x \
-    && v=`git describe --abbrev=4 --match="$prefix*" --tags HEAD 2>/dev/null \
-          || git describe --abbrev=4 --tags HEAD 2>/dev/null` \
+    && v=`git describe --abbrev=4 --match="$prefix*" HEAD 2>/dev/null \
+          || git describe --abbrev=4 HEAD 2>/dev/null` \
     && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \
     && case $v in
          $prefix[0-9]*) ;;

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Print a version string.
-scriptversion=2016-01-11.22; # UTC
+scriptversion=2018-08-31.20; # UTC
 
+# Copyright (C) 2018 Red Hat, Inc.
 # Copyright (C) 2007-2016 Free Software Foundation, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -49,6 +50,17 @@ scriptversion=2016-01-11.22; # UTC
 # .tarball-version is never generated in a VC'd directory, so needn't
 # be listed there.
 #
+# In order to use git archive versions another two files has to be presented:
+#
+# .gitarchive-version - present in checked-out repository and git
+#   archive tarball, but not in the distribution tarball. Used as a last
+#   option for version. File must contain special string $Format:%d$,
+#   which is substitued by git on archive operation.
+#
+# .gitattributes - present in checked-out repository and git archive
+#   tarball, but not in the distribution tarball. Must set export-subst
+#   attribute for .gitarchive-version file.
+#
 # Use the following line in your configure.ac, so that $(VERSION) will
 # automatically be up-to-date each time configure is run (and note that
 # since configure.ac no longer includes a version string, Makefile rules
@@ -80,7 +92,7 @@ under the terms of the GNU General Public License.
 For more information about these matters, see the files named COPYING."
 
 usage="\
-Usage: $me [OPTION]... \$srcdir/.tarball-version [TAG-NORMALIZATION-SED-SCRIPT]
+Usage: $me [OPTION]... \$srcdir/.tarball-version [\$srcdir/.gitarchive-version] [TAG-NORMALIZATION-SED-SCRIPT]
 Print a version string.
 
 Options:
@@ -110,6 +122,8 @@ while test $# -gt 0; do
     *)
       if test "x$tarball_version_file" = x; then
         tarball_version_file="$1"
+      elif test "x$gitarchive_version_file" = x; then
+        gitarchive_version_file="$1"
       elif test "x$tag_sed_script" = x; then
         tag_sed_script="$1"
       else
@@ -189,7 +203,22 @@ then
     v=`echo "$v" | sed 's/-/./;s/\(.*\)-g/\1-/'`;
     v_from_git=1
 elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
-    v=UNKNOWN
+    if test -f $gitarchive_version_file
+    then
+        v=`sed "s/^.*tag: \($prefix[0-9)][^,)]*\).*\$/\1/" $gitarchive_version_file \
+            | sed "$tag_sed_script"` || exit 1
+        case $v in
+            *$nl*) v= ;; # reject multi-line output
+            $prefix[0-9]*) ;;
+            *) v= ;;
+        esac
+
+        test -z "$v" \
+            && echo "$0: WARNING: $gitarchive_version_file doesn't contain valid version tag" 1>&2 \
+            && v=UNKNOWN
+    else
+        v=UNKNOWN
+    fi
 else
     v=$fallback
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 AC_PREREQ([2.63])
 AC_INIT([kronosnet],
-	m4_esyscmd([build-aux/git-version-gen .tarball-version]),
+	m4_esyscmd([build-aux/git-version-gen .tarball-version .gitarchivever]),
 	[devel@lists.kronosnet.org])
 # Don't let AC_PROC_CC (invoked by AC_USE_SYSTEM_EXTENSIONS) replace
 # undefined CFLAGS with -g -O2, overriding our special OPT_CFLAGS.


### PR DESCRIPTION
Port of https://github.com/ClusterLabs/libqb/pull/320. 2nd patch is optional and I'm happy to replace it by change of Makefile.am to support lightweight tags, but current situation (git-version-gen uses them and Makefile.am doesn't) seems like asking for a trouble.