### PR TITLE
Import key with length not dividable by wrap key block size

### DIFF
--- a/libknet/tests/api_knet_handle_crypto.c
+++ b/libknet/tests/api_knet_handle_crypto.c
@@ -170,6 +170,27 @@ static void test(const char *model)
 
 	flush_logs(logfds[0], stdout);
 
+	printf("Test knet_handle_crypto with %s/aes128/sha1 and key where (key_len %% wrap_key_block_size != 0)\n", model);
+
+	memset(&knet_handle_crypto_cfg, 0, sizeof(struct knet_handle_crypto_cfg));
+	strncpy(knet_handle_crypto_cfg.crypto_model, model, sizeof(knet_handle_crypto_cfg.crypto_model) - 1);
+	strncpy(knet_handle_crypto_cfg.crypto_cipher_type, "aes128", sizeof(knet_handle_crypto_cfg.crypto_cipher_type) - 1);
+	strncpy(knet_handle_crypto_cfg.crypto_hash_type, "sha1", sizeof(knet_handle_crypto_cfg.crypto_hash_type) - 1);
+	/*
+	 * Prime number so chance that (private_key_len % wrap_key_block_size == 0) is minimalized
+	 */
+	knet_handle_crypto_cfg.private_key_len = 2003;
+
+	if (knet_handle_crypto(knet_h, &knet_handle_crypto_cfg) < 0) {
+		printf("knet_handle_crypto doesn't accept private_ley with len 2003: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
 	printf("Shutdown crypto\n");
 
 	memset(&knet_handle_crypto_cfg, 0, sizeof(struct knet_handle_crypto_cfg));


### PR DESCRIPTION
Wrapping of the key is standard crypto operation which needs data
aligned to cipher block size, otherwise it fails.

Possible solution is to use a zero filled buffer with size alligned to
required wrap key block size. Private key is copied to the beginning of
the buffer and unwrap operation keeps using only required private key
size.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>

Another solutions I was thinking about, but discarded them for various reasons:
- Pad only required data instead using whole buffer (was actual first version - longer code with only small benefit when pad_key_data buffer is not dividable by wrap key block size)
- Force applications to use aligned key only - doable but we would ether need to export block size or use some safe value (like 64 bytes) = no need to change in knet but a lot more changes in apps using knet (corosync, corosync-keygen, ...)
