### PR TITLE
misc: keep covscan happy

### DIFF
--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -409,7 +409,7 @@ static pthread_mutex_t *openssl_internal_lock;
 static void openssl_internal_locking_callback(int mode, int type, char *file, int line)
 {
 	if (mode & CRYPTO_LOCK) {
-		pthread_mutex_lock(&(openssl_internal_lock[type]));
+		(void)pthread_mutex_lock(&(openssl_internal_lock[type]));
 	} else {
 		pthread_mutex_unlock(&(openssl_internal_lock[type]));
 	}

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -757,7 +757,7 @@ int knet_handle_free(knet_handle_t knet_h)
 	free(knet_h);
 	knet_h = NULL;
 
-	pthread_mutex_lock(&handle_config_mutex);
+	(void)pthread_mutex_lock(&handle_config_mutex);
 	knet_ref--;
 	_fini_shlib_tracker();
 	pthread_mutex_unlock(&handle_config_mutex);


### PR DESCRIPTION
covscan complains about is ignoring returns from pthread_mutex_lock()
but in those 2 circumstances we don't have much choice.

This patch just keeps coverity quiet so we don't miss any real bugs it
might find.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>