### PR TITLE
man: update XML directory in doxyxml.c

### DIFF
--- a/man/doxyxml.c
+++ b/man/doxyxml.c
@@ -31,7 +31,7 @@
 #include <qb/qblist.h>
 #include <qb/qbmap.h>
 
-#define XML_DIR "../../libknet/man/xml"
+#define XML_DIR "../man/xml-knet"
 #define XML_FILE "libknet_8h.xml"
 
 static int print_ascii = 1;


### PR DESCRIPTION
Fixes: 31945b18 ("[man] move libknet man pages and man pages build tools to top level dir")

Signed-off-by: Chen Jingpiao <chenjingpiao@gmail.com>