### PR TITLE
[build] fix supported compiler warning detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ cc_supports_flag() {
 		CPPFLAGS="-Werror $CPPFLAGS"
 	fi
 	AC_MSG_CHECKING([whether $CC supports "$@"])
-	AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
 			  [RC=0; AC_MSG_RESULT([yes])],
 			  [RC=1; AC_MSG_RESULT([no])])
 	CPPFLAGS="$saveCPPFLAGS"
@@ -409,6 +409,7 @@ WARNLIST="
 	missing-declarations
 	suggest-attribute=noreturn
 	suggest-attribute=format
+	property-attribute-mismatch
 	strict-prototypes
 	declaration-after-statement
 	pointer-arith
@@ -432,12 +433,14 @@ WARNLIST="
 	parentheses
 	sequence-point
 	switch
+	shift-overflow
 	shift-overflow=2
 	overlength-strings
 	retundent-decls
 	init-self
 	uninitialized
 	unused-but-set-variable
+	unused-const-variable
 	unused-function
 	unused-result
 	unused-value


### PR DESCRIPTION
move from AC_PREPROC_IFELSE (strongly discouraged) to AC_COMPILE_IFELSE

our detection system was very weak and recent versions of clang did
show that PREPROC_IFELFE (cpp) would enable warning options that
the compiler does not support (clang).

use a full compilation test to detect what works and what doesn't.

Also expand the warning list to include new / renamed clang options
of equivalents already enabled for older versions of clang and gcc.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>