### PR TITLE
[transports] fix transport_modules_cmd array out of range

### DIFF
--- a/libknet/transports.c
+++ b/libknet/transports.c
@@ -29,7 +29,7 @@
 
 #define empty_module 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL },
 
-knet_transport_ops_t transport_modules_cmd[] = {
+knet_transport_ops_t transport_modules_cmd[KNET_MAX_TRANSPORTS] = {
 	{ "LOOPBACK", KNET_TRANSPORT_LOOPBACK, 1, KNET_PMTUD_LOOPBACK_OVERHEAD, loopback_transport_init, loopback_transport_free, loopback_transport_link_set_config, loopback_transport_link_clear_config, loopback_transport_link_dyn_connect, loopback_transport_rx_sock_error, loopback_transport_tx_sock_error, loopback_transport_rx_is_data },
 	{ "UDP", KNET_TRANSPORT_UDP, 1, KNET_PMTUD_UDP_OVERHEAD, udp_transport_init, udp_transport_free, udp_transport_link_set_config, udp_transport_link_clear_config, udp_transport_link_dyn_connect, udp_transport_rx_sock_error, udp_transport_tx_sock_error, udp_transport_rx_is_data },
 	{ "SCTP", KNET_TRANSPORT_SCTP,


### PR DESCRIPTION
ARRAY_SIZE(transport_modules_cmd) = 4

* libknet/transports.c: knet_get_transport_name_by_id

```C
const char *knet_get_transport_name_by_id(uint8_t transport)
{
	int savederrno = 0;
	const char *name = NULL;

	if (transport == KNET_MAX_TRANSPORTS) {
		errno = EINVAL;
		return name;
	}

	if ((transport_modules_cmd[transport].transport_name) &&
	    (transport_modules_cmd[transport].built_in)) {
		name = transport_modules_cmd[transport].transport_name;
	} else {
		savederrno = ENOENT;
	}

	errno = savederrno;
	return name;
}
```

If transport >= 4 || transport < KNET_MAX_TRANSPORTS

   transport_modules_cmd[transport] is incorrect

* libknet/links.c: knet_link_set_config

```C
int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t link_id,
			 uint8_t transport,
			 struct sockaddr_storage *src_addr,
			 struct sockaddr_storage *dst_addr,
			 uint64_t flags)
{
	...

	if (transport >= KNET_MAX_TRANSPORTS) {
		errno = EINVAL;
		return -1;
	}

	...
	if (transport_link_set_config(knet_h, link, transport) < 0) {
		savederrno = errno;
		err = -1;
		goto exit_unlock;
	}
	...
}

int transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_link, uint8_t transport)
{
	if (!transport_modules_cmd[transport].built_in) {
		errno = EINVAL;
		return -1;
	}
	kn_link->transport_connected = 0;
	kn_link->transport_type = transport;
	kn_link->proto_overhead = transport_modules_cmd[transport].transport_mtu_overhead;
	return transport_modules_cmd[transport].transport_link_set_config(knet_h, kn_link);
}
```

In knet_link_set_config function we check transport >= KNET_MAX_TRANSPORTS instead
of transport >= ARRAY_SIZE(transport_modules_cmd),
so in transport_link_set_config function transport_modules_cmd[transport] is incorrect too.