### PR TITLE
[tx] fix compression stat collect in _parse_recv_from_sock

### DIFF
--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -375,7 +375,7 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 			}
 		}
 	}
-	if ((knet_h->compress_model > 0) && (inlen <= knet_h->compress_threshold)) {
+	if (knet_h->compress_model > 0 && !data_compressed) {
 		knet_h->stats.tx_uncompressed_packets++;
 	}
 

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -349,7 +349,7 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 			       knet_h->send_to_links_buf_compress, (ssize_t *)&cmp_outlen);
 		if (err < 0) {
 			log_warn(knet_h, KNET_SUB_COMPRESS, "Compression failed (%d): %s", err, strerror(errno));
-		} else {
+		} else if (cmp_outlen < inlen) {
 			/* Collect stats */
 			clock_gettime(CLOCK_MONOTONIC, &end_time);
 			timespec_diff(start_time, end_time, &compress_time);
@@ -368,11 +368,9 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 			knet_h->stats.tx_compressed_original_bytes += inlen;
 			knet_h->stats.tx_compressed_size_bytes += cmp_outlen;
 
-			if (cmp_outlen < inlen) {
-				memmove(inbuf->khp_data_userdata, knet_h->send_to_links_buf_compress, cmp_outlen);
-				inlen = cmp_outlen;
-				data_compressed = 1;
-			}
+			memmove(inbuf->khp_data_userdata, knet_h->send_to_links_buf_compress, cmp_outlen);
+			inlen = cmp_outlen;
+			data_compressed = 1;
 		}
 	}
 	if (knet_h->compress_model > 0 && !data_compressed) {


### PR DESCRIPTION
* [PATCH][tx] fix tx_uncompressed_packets stat collect in _parse_recv_from_sock

	After compression, inlen is not raw data length, we can not use it compare
	with compress_threshold.

	```C
	static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t channel, int is_sync)
	{
		...
		if ((knet_h->compress_model > 0) && (inlen > knet_h->compress_threshold)) {
			err = compress(knet_h,
				       (const unsigned char *)inbuf->khp_data_userdata, inlen,
				       knet_h->send_to_links_buf_compress, (ssize_t *)&cmp_outlen);
			if (err < 0) {
				log_warn(knet_h, KNET_SUB_COMPRESS, "Compression failed (%d): %s", err, strerror(errno));
			} else {

				if (cmp_outlen < inlen) {
					memmove(inbuf->khp_data_userdata, knet_h->send_to_links_buf_compress, cmp_outlen);
					inlen = cmp_outlen; /* here inlen has changes */
					data_compressed = 1;
				}
			}
		}
		/* inlen is not raw data length */
		if ((knet_h->compress_model > 0) && (inlen <= knet_h->compress_threshold)) {
			knet_h->stats.tx_uncompressed_packets++;
		}
		...
	}
	```

	Sorry, it's need a test but I no idea.

* [RFC][tx] update compression stat only when compressed data length shorter

	If data do not compressed, we do not update compression stat.