### PR TITLE
[tests] fix api_knet_{addrtostr,strtoaddr}.c

### DIFF
--- a/libknet/tests/api_knet_addrtostr.c
+++ b/libknet/tests/api_knet_addrtostr.c
@@ -35,7 +35,7 @@ static void test(void)
 	if (!knet_addrtostr(NULL, sizeof(struct sockaddr_storage),
 			    addr_str, KNET_MAX_HOST_LEN,
 			    port_str, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
-		printf("knet_addrtostr accepted invalid ss\n");
+		printf("knet_addrtostr accepted invalid ss or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 
@@ -44,7 +44,7 @@ static void test(void)
 	if (!knet_addrtostr(&addr, 0,
 			    addr_str, KNET_MAX_HOST_LEN,
 			    port_str, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
-		printf("knet_addrtostr accepted invalid sslen\n");
+		printf("knet_addrtostr accepted invalid sslen or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 
@@ -53,7 +53,7 @@ static void test(void)
 	if (!knet_addrtostr(&addr, sizeof(struct sockaddr_storage),
 			    NULL, KNET_MAX_HOST_LEN,
 			    port_str, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
-		printf("knet_addrtostr accepted invalid addr_str\n");
+		printf("knet_addrtostr accepted invalid addr_str or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 
@@ -62,7 +62,7 @@ static void test(void)
 	if (!knet_addrtostr(&addr, sizeof(struct sockaddr_storage),
 			    addr_str, KNET_MAX_HOST_LEN,
 			    NULL, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
-		printf("knet_addrtostr accepted invalid addr_str\n");
+		printf("knet_addrtostr accepted invalid addr_str or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 

--- a/libknet/tests/api_knet_addrtostr.c
+++ b/libknet/tests/api_knet_addrtostr.c
@@ -34,7 +34,7 @@ static void test(void)
 
 	if (!knet_addrtostr(NULL, sizeof(struct sockaddr_storage),
 			    addr_str, KNET_MAX_HOST_LEN,
-			    port_str, KNET_MAX_PORT_LEN) && (errno != EINVAL)) {
+			    port_str, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
 		printf("knet_addrtostr accepted invalid ss\n");
 		exit(FAIL);
 	}
@@ -43,7 +43,7 @@ static void test(void)
 
 	if (!knet_addrtostr(&addr, 0,
 			    addr_str, KNET_MAX_HOST_LEN,
-			    port_str, KNET_MAX_PORT_LEN) && (errno != EINVAL)) {
+			    port_str, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
 		printf("knet_addrtostr accepted invalid sslen\n");
 		exit(FAIL);
 	}
@@ -52,7 +52,7 @@ static void test(void)
 
 	if (!knet_addrtostr(&addr, sizeof(struct sockaddr_storage),
 			    NULL, KNET_MAX_HOST_LEN,
-			    port_str, KNET_MAX_PORT_LEN) && (errno != EINVAL)) {
+			    port_str, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
 		printf("knet_addrtostr accepted invalid addr_str\n");
 		exit(FAIL);
 	}
@@ -61,7 +61,7 @@ static void test(void)
 
 	if (!knet_addrtostr(&addr, sizeof(struct sockaddr_storage),
 			    addr_str, KNET_MAX_HOST_LEN,
-			    NULL, KNET_MAX_PORT_LEN) && (errno != EINVAL)) {
+			    NULL, KNET_MAX_PORT_LEN) || (errno != EINVAL)) {
 		printf("knet_addrtostr accepted invalid addr_str\n");
 		exit(FAIL);
 	}

--- a/libknet/tests/api_knet_strtoaddr.c
+++ b/libknet/tests/api_knet_strtoaddr.c
@@ -34,7 +34,7 @@ static void test(void)
 
 	printf("Checking knet_strtoaddr with invalid host\n");
 
-	if (!knet_strtoaddr(NULL, "50000", &out_addr, sizeof(struct sockaddr_storage)) &&
+	if (!knet_strtoaddr(NULL, "50000", &out_addr, sizeof(struct sockaddr_storage)) ||
 	    (errno != EINVAL)) {
 		printf("knet_strtoaddr accepted invalid host\n");
 		exit(FAIL);
@@ -42,7 +42,7 @@ static void test(void)
 
 	printf("Checking knet_strtoaddr with invalid port\n");
 
-	if (!knet_strtoaddr("127.0.0.1", NULL, &out_addr, sizeof(struct sockaddr_storage)) &&
+	if (!knet_strtoaddr("127.0.0.1", NULL, &out_addr, sizeof(struct sockaddr_storage)) ||
 	    (errno != EINVAL)) {
 		printf("knet_strtoaddr accepted invalid port\n");
 		exit(FAIL);
@@ -50,7 +50,7 @@ static void test(void)
 
 	printf("Checking knet_strtoaddr with invalid addr\n");
 
-	if (!knet_strtoaddr("127.0.0.1", "50000", NULL, sizeof(struct sockaddr_storage)) &&
+	if (!knet_strtoaddr("127.0.0.1", "50000", NULL, sizeof(struct sockaddr_storage)) ||
 	    (errno != EINVAL)) {
 		printf("knet_strtoaddr accepted invalid addr\n");
 		exit(FAIL);
@@ -58,7 +58,7 @@ static void test(void)
 
 	printf("Checking knet_strtoaddr with invalid size\n");
 
-	if (!knet_strtoaddr("127.0.0.1", "50000", &out_addr, 0) &&
+	if (!knet_strtoaddr("127.0.0.1", "50000", &out_addr, 0) ||
 	    (errno != EINVAL)) {
 		printf("knet_strtoaddr accepted invalid size\n");
 		exit(FAIL);

--- a/libknet/tests/api_knet_strtoaddr.c
+++ b/libknet/tests/api_knet_strtoaddr.c
@@ -36,7 +36,7 @@ static void test(void)
 
 	if (!knet_strtoaddr(NULL, "50000", &out_addr, sizeof(struct sockaddr_storage)) ||
 	    (errno != EINVAL)) {
-		printf("knet_strtoaddr accepted invalid host\n");
+		printf("knet_strtoaddr accepted invalid host or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 
@@ -44,7 +44,7 @@ static void test(void)
 
 	if (!knet_strtoaddr("127.0.0.1", NULL, &out_addr, sizeof(struct sockaddr_storage)) ||
 	    (errno != EINVAL)) {
-		printf("knet_strtoaddr accepted invalid port\n");
+		printf("knet_strtoaddr accepted invalid port or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 
@@ -52,7 +52,7 @@ static void test(void)
 
 	if (!knet_strtoaddr("127.0.0.1", "50000", NULL, sizeof(struct sockaddr_storage)) ||
 	    (errno != EINVAL)) {
-		printf("knet_strtoaddr accepted invalid addr\n");
+		printf("knet_strtoaddr accepted invalid addr or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 
@@ -60,7 +60,7 @@ static void test(void)
 
 	if (!knet_strtoaddr("127.0.0.1", "50000", &out_addr, 0) ||
 	    (errno != EINVAL)) {
-		printf("knet_strtoaddr accepted invalid size\n");
+		printf("knet_strtoaddr accepted invalid size or returned incorrect error: %s\n", strerror(errno));
 		exit(FAIL);
 	}
 


### PR DESCRIPTION
```C
if (!knet_strtoaddr(NULL, "50000", &out_addr, sizeof(struct sockaddr_storage)) && (errno != EINVAL)) {
}
```

if !knet_strtoaddr() is true, only when last fail call set errno to EINVAL, the above condition is true;
we should change to:


```C
if (!knet_strtoaddr(NULL, "50000", &out_addr, sizeof(struct sockaddr_storage))) {
}
```

or, if make sure to clear errno before you hit the test. (Other tests is in this way)

```C
if (!knet_strtoaddr(NULL, "50000", &out_addr, sizeof(struct sockaddr_storage)) || (errno != EINVAL)) {
}
```