### PR TITLE
[libknet] bump soname due to ABI changes introduced in e1536067d2ade7…

### DIFF
--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -18,7 +18,7 @@ EXTRA_DIST		= $(SYMFILE)
 SUBDIRS			= . tests
 
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-libversion		= 2:0:1
+libversion		= 2:0:0
 
 # override global LIBS that pulls in lots of craft we don't need here
 LIBS			=


### PR DESCRIPTION
…c184e80b9fcc233d309f4d7c01

soname 2.0.0 will stay around till stable2 is branched.
followers of the master branch should know what they are dealing with.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>