### PR TITLE
[libknet] logging: add handle information in log structure

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -1921,6 +1921,7 @@ struct knet_log_msg {
 	char	msg[KNET_MAX_LOG_MSG_SIZE];
 	uint8_t	subsystem;	/* KNET_SUB_* */
 	uint8_t msglevel;	/* KNET_LOG_* */
+	knet_handle_t knet_h;	/* pointer to the handle generating the log */
 };
 
 /**

--- a/libknet/logging.c
+++ b/libknet/logging.c
@@ -221,6 +221,7 @@ void log_msg(knet_handle_t knet_h, uint8_t subsystem, uint8_t msglevel,
 	memset(&msg, 0, sizeof(struct knet_log_msg));
 	msg.subsystem = subsystem;
 	msg.msglevel = msglevel;
+	msg.knet_h = knet_h;
 
 	va_start(ap, fmt);
 #ifdef __clang__

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -233,6 +233,15 @@ void flush_logs(int logfd, FILE *std)
 			bytes_read += len;
 		}
 
+		if (!msg.knet_h) {
+			/*
+			 * this is harsh but this function is void
+			 * and it is used also inside log_thread.
+			 * this is the easiest to get out with an error
+			 */
+			fprintf(std, "NO HANDLE INFO IN LOG MSG!!\n");
+			abort();
+		}
 		fprintf(std, "[knet]: [%s] %s: %.*s\n",
 			knet_log_get_loglevel_name(msg.msglevel),
 			knet_log_get_subsystem_name(msg.subsystem),


### PR DESCRIPTION
Use case: an app is using the same fd to gather logs from
multiple knet_h, the app might still require to know which
knet_h has generated the log for better logging purposes.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>