### PR TITLE
[build] improve compiler parameter checking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,7 +180,7 @@ AM_CONDITIONAL([BUILD_LIBNOZZLE], [test x$enable_libnozzle = xyes])
 # args. Global CPPFLAGS are ignored during this test.
 cc_supports_flag() {
 	saveCPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$@"
+	CPPFLAGS="$EXTRA_WARNINGS $@"
 	if echo $CC | grep -q clang; then
 		CPPFLAGS="-Werror $CPPFLAGS"
 	fi


### PR DESCRIPTION
in the old way of checking compiler extra warnings, we would
check one warning at a time, but it doesn't really detect
incompatiblities between parameters till we attempt to build
the first object.

pass EXTRA_WARNINGS to the function that does check for parameters
in a cumulative fashion, so that potential incompatibilities can
be detected at configure time vs build time.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>