### PR TITLE
[common] fix not reporting a true dlinfo error cause

### DIFF
--- a/libknet/common.c
+++ b/libknet/common.c
@@ -82,6 +82,7 @@ static void *open_lib(knet_handle_t knet_h, const char *libname, int extra_flags
 		/*
 		 * should we dlclose and return error?
 		 */
+		error = dlerror();
 		log_warn(knet_h, KNET_SUB_COMMON, "unable to dlinfo %s: %s",
 			 libname, error);
 	} else {


### PR DESCRIPTION
This was automatically caught with GCC 9
("'%s' directive argument is null").