### PR TITLE
Allow users to manage internal timers

### DIFF
--- a/build-aux/knet_valgrind_memcheck.supp
+++ b/build-aux/knet_valgrind_memcheck.supp
@@ -588,3 +588,20 @@
    obj:/usr/lib64/libnss3.so
    obj:/usr/lib64/libnss3.so
 }
+{
+   nss internal leak (3.41) non recurring (spotted on f29)
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:/usr/lib64/libnss3.so
+}

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -1656,3 +1656,34 @@ int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
 	errno = err ? savederrno : 0;
 	return err;
 }
+
+int knet_handle_get_threads_timer_res(knet_handle_t knet_h,
+				      useconds_t *timeres)
+{
+	int savederrno = 0;
+	int err = 0;
+
+	if (!knet_h) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (!timeres) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	savederrno = pthread_rwlock_rdlock(&knet_h->global_rwlock);
+	if (savederrno) {
+		log_err(knet_h, KNET_SUB_HANDLE, "Unable to get read lock: %s",
+			strerror(savederrno));
+		errno = savederrno;
+		return -1;
+	}
+
+	*timeres = knet_h->threads_timer_res;
+
+	pthread_rwlock_unlock(&knet_h->global_rwlock);
+	errno = err ? savederrno : 0;
+	return err;
+}

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -600,6 +600,12 @@ knet_handle_t knet_handle_new(knet_node_id_t host_id,
 	}
 
 	/*
+	 * set internal threads time resolutions
+	 */
+
+	knet_h->threads_timer_res = KNET_THREADS_TIMER_RES;
+
+	/*
 	 * set pmtud default timers
 	 */
 	knet_h->pmtud_interval = KNET_PMTUD_DEFAULT_INTERVAL;
@@ -1609,3 +1615,44 @@ int knet_handle_clear_stats(knet_handle_t knet_h, int clear_option)
 	return err;
 }
 
+int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
+				      useconds_t timeres)
+{
+	int savederrno = 0;
+	int err = 0;
+
+	if (!knet_h) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	/*
+	 * most threads use timeres / 1000 as timeout on epoll.
+	 * anything below 1000 would generate a result of 0, making
+	 * the threads spin at 100% cpu
+	 */
+	if ((timeres > 0) && (timeres < 1000)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	savederrno = get_global_wrlock(knet_h);
+	if (savederrno) {
+		log_err(knet_h, KNET_SUB_HANDLE, "Unable to get write lock: %s",
+			strerror(savederrno));
+		errno = savederrno;
+		return -1;
+	}
+
+	if (timeres) {
+		knet_h->threads_timer_res = timeres;
+		log_debug(knet_h, KNET_SUB_HANDLE, "Setting new threads timer resolution to %u usecs", knet_h->threads_timer_res);
+	} else {
+		knet_h->threads_timer_res = KNET_THREADS_TIMER_RES;
+		log_debug(knet_h, KNET_SUB_HANDLE, "Setting new threads timer resolution to default %u usecs", knet_h->threads_timer_res);
+	}
+
+	pthread_rwlock_unlock(&knet_h->global_rwlock);
+	errno = err ? savederrno : 0;
+	return err;
+}

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -176,6 +176,7 @@ struct knet_handle {
 	struct knet_header *pingbuf;
 	struct knet_header *pmtudbuf;
 	uint8_t threads_status[KNET_THREAD_MAX];
+	useconds_t threads_timer_res;
 	pthread_mutex_t threads_status_mutex;
 	pthread_t send_to_links_thread;
 	pthread_t recv_from_links_thread;

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -88,6 +88,12 @@ typedef uint16_t knet_node_id_t;
 
 #define KNET_HANDLE_FLAG_PRIVILEGED (1ULL << 0)
 
+/*
+ * threads timer resolution (see knet_handle_set_threads_timer_res below)
+ */
+
+#define KNET_THREADS_TIMER_RES 200000
+
 typedef struct knet_handle *knet_handle_t;
 
 /*
@@ -152,6 +158,40 @@ knet_handle_t knet_handle_new(knet_node_id_t host_id,
  */
 
 int knet_handle_free(knet_handle_t knet_h);
+
+/**
+ * knet_handle_set_threads_timer_res
+ * @brief Change internal thread timer resolution
+ *
+ * knet_h   - pointer to knet_handle_t
+ *
+ * timeres  - some threads inside knet will use usleep(timeres)
+ *            to check if any activity has to be performed, or wait
+ *            for the next cycle. 'timeres' (expressed in nano seconds)
+ *            defines this interval, with a default of KNET_THREADS_TIMER_RES
+ *            (200000).
+ *            The lower this value is, the more often knet will perform
+ *            those checks and allows a more (time) precise execution of
+ *            some operations (for example ping/pong), at the cost of higher
+ *            CPU usage.
+ *            Accepted values:
+ *            0 - reset timer res to default
+ *            1 - 999 invalid (as it would cause 100% CPU spinning on some
+ *                    epoll operations)
+ *            1000 or higher - valid
+ *
+ * Unless you know exactly what you are doing, stay away from
+ * changing the default or seek written and notarized approval
+ * from the knet developer team.
+ *
+ * @return
+ * knet_handle_set_threads_timer_res returns
+ * 0 on success
+ * -1 on error and errno is set.
+ */
+
+int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
+				      useconds_t timeres);
 
 /**
  * knet_handle_enable_sock_notify

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -194,6 +194,23 @@ int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
 				      useconds_t timeres);
 
 /**
+ * knet_handle_get_threads_timer_res
+ * @brief Get internal thread timer resolutions
+ *
+ * knet_h   - pointer to knet_handle_t
+ *
+ * timeres  - current timer res value
+ *
+ * @return
+ * knet_handle_set_threads_timer_res returns
+ * 0 on success and timerres will contain the current value
+ * -1 on error and errno is set.
+ */
+
+int knet_handle_get_threads_timer_res(knet_handle_t knet_h,
+				      useconds_t *timeres);
+
+/**
  * knet_handle_enable_sock_notify
  * @brief Register a callback to receive socket events
  *

--- a/libknet/tests/api-check.mk
+++ b/libknet/tests/api-check.mk
@@ -69,7 +69,8 @@ api_checks		= \
 			  api_knet_link_get_link_list_test \
 			  api_knet_link_get_status_test \
 			  api_knet_link_enable_status_change_notify_test \
-			  api_knet_handle_set_threads_timer_res_test
+			  api_knet_handle_set_threads_timer_res_test \
+			  api_knet_handle_get_threads_timer_res_test
 
 api_knet_handle_new_test_SOURCES = api_knet_handle_new.c \
 				   test-common.c
@@ -259,4 +260,7 @@ api_knet_link_enable_status_change_notify_test_SOURCES = api_knet_link_enable_st
 							 test-common.c
 
 api_knet_handle_set_threads_timer_res_test_SOURCES = api_knet_handle_set_threads_timer_res.c \
+						     test-common.c
+
+api_knet_handle_get_threads_timer_res_test_SOURCES = api_knet_handle_get_threads_timer_res.c \
 						     test-common.c

--- a/libknet/tests/api-check.mk
+++ b/libknet/tests/api-check.mk
@@ -68,7 +68,8 @@ api_checks		= \
 			  api_knet_link_get_enable_test \
 			  api_knet_link_get_link_list_test \
 			  api_knet_link_get_status_test \
-			  api_knet_link_enable_status_change_notify_test
+			  api_knet_link_enable_status_change_notify_test \
+			  api_knet_handle_set_threads_timer_res_test
 
 api_knet_handle_new_test_SOURCES = api_knet_handle_new.c \
 				   test-common.c
@@ -256,3 +257,6 @@ api_knet_link_get_status_test_SOURCES = api_knet_link_get_status.c \
 
 api_knet_link_enable_status_change_notify_test_SOURCES = api_knet_link_enable_status_change_notify.c \
 							 test-common.c
+
+api_knet_handle_set_threads_timer_res_test_SOURCES = api_knet_handle_set_threads_timer_res.c \
+						     test-common.c

--- a/libknet/tests/api_knet_handle_get_threads_timer_res.c
+++ b/libknet/tests/api_knet_handle_get_threads_timer_res.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) -2019 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
+ *
+ * This software licensed under GPL-2.0+, LGPL-2.0+
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "libknet.h"
+
+#include "internals.h"
+#include "test-common.h"
+
+static void test(void)
+{
+	knet_handle_t knet_h;
+	int logfds[2];
+	useconds_t timeres;
+
+	printf("Test knet_handle_get_threads_timer_res incorrect knet_h\n");
+
+	if ((!knet_handle_get_threads_timer_res(NULL, &timeres)) || (errno != EINVAL)) {
+		printf("knet_handle_get_threads_timer_res accepted invalid knet_h or returned incorrect error: %s\n", strerror(errno));
+		exit(FAIL);
+	}
+
+	setup_logpipes(logfds);
+
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
+
+	printf("Test knet_handle_get_threads_timer_res with invalid timeres\n");
+
+	if ((!knet_handle_get_threads_timer_res(knet_h, NULL)) || (errno != EINVAL)) {
+		printf("knet_handle_get_threads_timer_res accepted invalid timeres or returned incorrect error: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	printf("Test knet_handle_get_threads_timer_res with valid timeres\n");
+
+	if (knet_handle_get_threads_timer_res(knet_h, &timeres)) {
+		printf("knet_handle_get_threads_timer_res did not accept valid timeres: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	if (timeres != knet_h->threads_timer_res) {
+		printf("knet_handle_get_threads_timer_res did not get timeres correct value: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	printf("Test knet_handle_get_threads_timer_res with valid timeres\n");
+
+	if (knet_handle_set_threads_timer_res(knet_h, 1000)) {
+		printf("knet_handle_set_threads_timer_res did not accept valid timeres: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	if (knet_handle_get_threads_timer_res(knet_h, &timeres)) {
+		printf("knet_handle_get_threads_timer_res did not accept valid timeres: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	if (timeres != knet_h->threads_timer_res) {
+		printf("knet_handle_get_threads_timer_res did not get timeres correct value: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	knet_handle_free(knet_h);
+	flush_logs(logfds[0], stdout);
+	close_logpipes(logfds);
+}
+
+int main(int argc, char *argv[])
+{
+	test();
+
+	return PASS;
+}

--- a/libknet/tests/api_knet_handle_set_threads_timer_res.c
+++ b/libknet/tests/api_knet_handle_set_threads_timer_res.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
+ *
+ * This software licensed under GPL-2.0+, LGPL-2.0+
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "libknet.h"
+
+#include "internals.h"
+#include "test-common.h"
+
+static void test(void)
+{
+	knet_handle_t knet_h;
+	int logfds[2];
+
+	printf("Test knet_handle_set_threads_timer_res incorrect knet_h\n");
+
+	if ((!knet_handle_set_threads_timer_res(NULL, 0)) || (errno != EINVAL)) {
+		printf("knet_handle_set_threads_timer_res accepted invalid knet_h or returned incorrect error: %s\n", strerror(errno));
+		exit(FAIL);
+	}
+
+	setup_logpipes(logfds);
+
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
+
+	printf("Test knet_handle_set_threads_timer_res with invalid timeres\n");
+
+	if ((!knet_handle_set_threads_timer_res(knet_h, 999)) || (errno != EINVAL)) {
+		printf("knet_handle_set_threads_timer_res accepted invalid timeres or returned incorrect error: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	printf("Test knet_handle_set_threads_timer_res with valid timeres\n");
+
+	if (knet_handle_set_threads_timer_res(knet_h, 2000)) {
+		printf("knet_handle_set_threads_timer_res did not accept valid timeres: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	if (knet_h->threads_timer_res != 2000) {
+		printf("knet_handle_set_threads_timer_res did not set timeres to correct value: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	knet_handle_free(knet_h);
+	flush_logs(logfds[0], stdout);
+	close_logpipes(logfds);
+}
+
+int main(int argc, char *argv[])
+{
+	test();
+
+	return PASS;
+}

--- a/libknet/tests/knet_bench.c
+++ b/libknet/tests/knet_bench.c
@@ -24,7 +24,6 @@
 #include "internals.h"
 #include "netutils.h"
 #include "transport_common.h"
-#include "threads_common.h"
 #include "test-common.h"
 
 #define MAX_NODES 128
@@ -818,7 +817,7 @@ retry:
 
 	if (sent_msgs < 0) {
 		if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
-			usleep(KNET_THREADS_TIMERES / 16);
+			usleep(KNET_THREADS_TIMER_RES / 16);
 			goto retry;
 		}
 		printf("[info]: Unable to send messages: %s\n", strerror(errno));

--- a/libknet/threads_common.c
+++ b/libknet/threads_common.c
@@ -130,7 +130,7 @@ int wait_all_threads_status(knet_handle_t knet_h, uint8_t status)
 	uint8_t i = 0, found = 0;
 
 	while (!found) {
-		usleep(KNET_THREADS_TIMERES);
+		usleep(knet_h->threads_timer_res);
 
 		if (pthread_mutex_lock(&knet_h->threads_status_mutex) != 0) {
 			continue;

--- a/libknet/threads_common.h
+++ b/libknet/threads_common.h
@@ -12,8 +12,6 @@
 
 #include "internals.h"
 
-#define KNET_THREADS_TIMERES 200000
-
 #define KNET_THREAD_UNREGISTERED	0 /* thread does not exist */
 #define KNET_THREAD_REGISTERED		1 /* thread has been registered before  pthread_create invocation.
 					     make sure threads are registered before calling wait_all_thread_status */

--- a/libknet/threads_dsthandler.c
+++ b/libknet/threads_dsthandler.c
@@ -56,7 +56,7 @@ void *_handle_dst_link_handler_thread(void *data)
 	set_thread_status(knet_h, KNET_THREAD_DST_LINK, KNET_THREAD_STARTED);
 
 	while (!shutdown_in_progress(knet_h)) {
-		if (epoll_wait(knet_h->dst_link_handler_epollfd, events, KNET_EPOLL_MAX_EVENTS, KNET_THREADS_TIMERES / 1000) >= 1)
+		if (epoll_wait(knet_h->dst_link_handler_epollfd, events, KNET_EPOLL_MAX_EVENTS, knet_h->threads_timer_res / 1000) >= 1)
 			_handle_dst_link_updates(knet_h);
 	}
 

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -194,7 +194,7 @@ void *_handle_heartbt_thread(void *data)
 	knet_h->pingbuf->kh_node = htons(knet_h->host_id);
 
 	while (!shutdown_in_progress(knet_h)) {
-		usleep(KNET_THREADS_TIMERES);
+		usleep(knet_h->threads_timer_res);
 
 		if (pthread_rwlock_rdlock(&knet_h->global_rwlock) != 0) {
 			log_debug(knet_h, KNET_SUB_HEARTBEAT, "Unable to get read lock");
@@ -204,7 +204,7 @@ void *_handle_heartbt_thread(void *data)
 		/*
 		 *  _adjust_pong_timeouts should execute approx once a second.
 		 */
-		if ((i % (1000000 / KNET_THREADS_TIMERES)) == 0) {
+		if ((i % (1000000 / knet_h->threads_timer_res)) == 0) {
 			_adjust_pong_timeouts(knet_h);
 			i = 1;
 		} else {

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -489,7 +489,7 @@ void *_handle_pmtud_link_thread(void *data)
 	knet_h->pmtudbuf->kh_node = htons(knet_h->host_id);
 
 	while (!shutdown_in_progress(knet_h)) {
-		usleep(KNET_THREADS_TIMERES);
+		usleep(knet_h->threads_timer_res);
 
 		if (pthread_mutex_lock(&knet_h->pmtud_mutex) != 0) {
 			log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get mutex lock");

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -832,7 +832,7 @@ void *_handle_recv_from_links_thread(void *data)
 	}
 
 	while (!shutdown_in_progress(knet_h)) {
-		nev = epoll_wait(knet_h->recv_from_links_epollfd, events, KNET_EPOLL_MAX_EVENTS, KNET_THREADS_TIMERES / 1000);
+		nev = epoll_wait(knet_h->recv_from_links_epollfd, events, KNET_EPOLL_MAX_EVENTS, knet_h->threads_timer_res / 1000);
 
 		/*
 		 * we use timeout to detect if thread is shutting down

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -235,7 +235,7 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 						local_link->status.stats.tx_data_retries++;
 						buf += err;
 						buflen -= err;
-						usleep(KNET_THREADS_TIMERES / 16);
+						usleep(knet_h->threads_timer_res / 16);
 						goto local_retry;
 					}
 					if (err == buflen) {
@@ -704,7 +704,7 @@ void *_handle_send_to_links_thread(void *data)
 	}
 
 	while (!shutdown_in_progress(knet_h)) {
-		nev = epoll_wait(knet_h->send_to_links_epollfd, events, KNET_EPOLL_MAX_EVENTS + 1, KNET_THREADS_TIMERES / 1000);
+		nev = epoll_wait(knet_h->send_to_links_epollfd, events, KNET_EPOLL_MAX_EVENTS + 1, knet_h->threads_timer_res / 1000);
 
 		/*
 		 * we use timeout to detect if thread is shutting down

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -300,7 +300,7 @@ int sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err,
 #endif
 			/* Don't hold onto the lock while sleeping */
 			pthread_rwlock_unlock(&knet_h->global_rwlock);
-			usleep(KNET_THREADS_TIMERES / 16);
+			usleep(knet_h->threads_timer_res / 16);
 			pthread_rwlock_rdlock(&knet_h->global_rwlock);
 			return 1;
 		}
@@ -406,7 +406,7 @@ int sctp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err,
 
 	/* Don't hold onto the lock while sleeping */
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
-	usleep(KNET_THREADS_TIMERES / 2);
+	usleep(knet_h->threads_timer_res / 2);
 	pthread_rwlock_rdlock(&knet_h->global_rwlock);
 	return 0;
 }
@@ -629,7 +629,7 @@ static void *_sctp_connect_thread(void *data)
 	set_thread_status(knet_h, KNET_THREAD_SCTP_CONN, KNET_THREAD_STARTED);
 
 	while (!shutdown_in_progress(knet_h)) {
-		nev = epoll_wait(handle_info->connect_epollfd, events, KNET_EPOLL_MAX_EVENTS, KNET_THREADS_TIMERES / 1000);
+		nev = epoll_wait(handle_info->connect_epollfd, events, KNET_EPOLL_MAX_EVENTS, knet_h->threads_timer_res / 1000);
 
 		/*
 		 * we use timeout to detect if thread is shutting down
@@ -874,7 +874,7 @@ static void *_sctp_listen_thread(void *data)
 	set_thread_status(knet_h, KNET_THREAD_SCTP_LISTEN, KNET_THREAD_STARTED);
 
 	while (!shutdown_in_progress(knet_h)) {
-		nev = epoll_wait(handle_info->listen_epollfd, events, KNET_EPOLL_MAX_EVENTS, KNET_THREADS_TIMERES / 1000);
+		nev = epoll_wait(handle_info->listen_epollfd, events, KNET_EPOLL_MAX_EVENTS, knet_h->threads_timer_res / 1000);
 
 		/*
 		 * we use timeout to detect if thread is shutting down

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -408,7 +408,7 @@ int udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, 
 #ifdef DEBUG
 			log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is overloaded. Slowing TX down", sockfd);
 #endif
-			usleep(KNET_THREADS_TIMERES / 16);
+			usleep(knet_h->threads_timer_res / 16);
 		} else {
 			read_errs_from_sock(knet_h, sockfd);
 		}


### PR DESCRIPTION
after investigating the latest issues with firewalld reload, it was clear that internal timer resolution default might not be ideal for all configuration.

This patch is NOT complete, but I wanted to discuss the idea of allowing timers to be configurable as a general concept.

Low timers == higher CPU usage...

Perhaps we need to be able to tune all timers separately but it seems overkilling.