### PR TITLE
File lock should be blocked when conflict writing

### DIFF
--- a/kronosnetd/main.c
+++ b/kronosnetd/main.c
@@ -177,7 +177,7 @@ static int create_lockfile(const char *lockfile)
 
 retry_fcntl:
 
-	if (fcntl(fd, F_SETLK, &lock) < 0) {
+	if (fcntl(fd, F_SETLKW, &lock) < 0) {
 		switch (errno) {
 		case EINTR:
 			goto retry_fcntl;


### PR DESCRIPTION
F_SETLKW should be used to wait for lock release.
EINTR error number require to set "F_SETLKW",
the conflict process will block there and wait for
the lock relasesd. In this code, it will goto "retry",
or it would never try again.

Signed-off-by: yuan ren <yren@suse.com>