### PR TITLE
Fix fd race condition in multi-thread program

### DIFF
--- a/libknet/common.c
+++ b/libknet/common.c
@@ -22,38 +22,6 @@
 #include "logging.h"
 #include "common.h"
 
-int _fdset_cloexec(int fd)
-{
-	int fdflags;
-
-	fdflags = fcntl(fd, F_GETFD, 0);
-	if (fdflags < 0)
-		return -1;
-
-	fdflags |= FD_CLOEXEC;
-
-	if (fcntl(fd, F_SETFD, fdflags) < 0)
-		return -1;
-
-	return 0;
-}
-
-int _fdset_nonblock(int fd)
-{
-	int fdflags;
-
-	fdflags = fcntl(fd, F_GETFL, 0);
-	if (fdflags < 0)
-		return -1;
-
-	fdflags |= O_NONBLOCK;
-
-	if (fcntl(fd, F_SETFL, fdflags) < 0)
-		return -1;
-
-	return 0;
-}
-
 static void *open_lib(knet_handle_t knet_h, const char *libname, int extra_flags)
 {
 	void *ret = NULL;

--- a/libknet/common.h
+++ b/libknet/common.h
@@ -12,8 +12,6 @@
 #ifndef __KNET_COMMON_H__
 #define __KNET_COMMON_H__
 
-int _fdset_cloexec(int fd);
-int _fdset_nonblock(int fd);
 void *load_module(knet_handle_t knet_h, const char *type, const char *name);
 
 #endif

--- a/libknet/compat.c
+++ b/libknet/compat.c
@@ -35,7 +35,7 @@ _poll_to_filter_(int32_t event)
 	return out;
 }
 
-int epoll_create(int size)
+int epoll_create1(int flags)
 {
 	return kqueue();
 }

--- a/libknet/compat.h
+++ b/libknet/compat.h
@@ -41,7 +41,7 @@ struct epoll_event {
 	epoll_data_t data;        /* User data variable */
 };
 
-int epoll_create(int size);
+int epoll_create1(int flags);
 int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event);
 int epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout_ms);
 

--- a/libknet/tests/knet_bench.c
+++ b/libknet/tests/knet_bench.c
@@ -656,7 +656,7 @@ static void *_rx_thread(void *args)
 		msg[i].msg_hdr.msg_iovlen = 1;
 	}
 
-	rx_epoll = epoll_create(KNET_EPOLL_MAX_EVENTS + 1);
+	rx_epoll = epoll_create1(EPOLL_CLOEXEC);
 	if (rx_epoll < 0) {
 		printf("RXT: Unable to create epoll!\nHALTING RX THREAD!\n");
 		return NULL;

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -151,22 +151,6 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 	int err = 0, savederrno = 0;
 	int value;
 
-	if (_fdset_cloexec(sock)) {
-		savederrno = errno;
-		err = -1;
-		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s CLOEXEC socket opts: %s",
-			type, strerror(savederrno));
-		goto exit_error;
-	}
-
-	if (_fdset_nonblock(sock)) {
-		savederrno = errno;
-		err = -1;
-		log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s NONBLOCK socket opts: %s",
-			type, strerror(savederrno));
-		goto exit_error;
-	}
-
 	if (_configure_sockbuf(knet_h, sock, SO_RCVBUF, SO_RCVBUFFORCE, KNET_RING_RCVBUFF)) {
 		savederrno = errno;
 		err = -1;

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -72,7 +72,7 @@ int udp_transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_lin
 		goto exit_error;
 	}
 
-	sock = socket(kn_link->src_addr.ss_family, SOCK_DGRAM, 0);
+	sock = socket(kn_link->src_addr.ss_family, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
 	if (sock < 0) {
 		savederrno = errno;
 		err = -1;


### PR DESCRIPTION
The size argument is ignored since Linux 2.6.8 in "epoll_create". So,
We choose the "epoll_create1" and specific the close-on-exec flag FLAG
is "EPOLL_CLOEXEC". Please refer epoll_create(2).
Btw, the function "_fdset_cloexec" not stable than O_CLOEXEC flag to be
set directly, SOCK_CLOEXEC is used in socket fd. Because using a separate
fcntl(2) F_SETFD operation to set the FD_CLOEXEC flag does not suffice to
avoid race conditions where one thread opens a file descriptor and
attempts to set its close-on-exec flag using fcntl(2) at the same time as
another thread does a fork(2) plus execve(2).[referenced: open(2)]