### PR TITLE
udp: Don't spin if a node has the wrong IP family

### DIFF
--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -400,7 +400,7 @@ int udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, 
 			read_errs_from_sock(knet_h, sockfd);
 			return 0;
 		}
-		if (recv_errno == EINVAL || recv_errno == EPERM) {
+		if (recv_errno == EINVAL || recv_errno == EPERM || recv_errno == EAFNOSUPPORT) {
 			return -1;
 		}
 		if ((recv_errno == ENOBUFS) || (recv_errno == EAGAIN)) {


### PR DESCRIPTION
If a link has nodes with a mix of IP families (eg it's set up
with IPv4 ones and an IPv6 one is added) then knet spins on sending
to an IPv6 one from a IPv4 socket with -EAFNOSUPPORT.

Yes, this is a bad config error but knet should handle it with a
little more grace.

sctp does not seem to suffer from the spinning at least

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>