### PR TITLE
link: Check address families on a link always match

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 
 Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
          Christine Caulfield <ccaulfie@redhat.com>

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/build-aux/check.mk
+++ b/build-aux/check.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -2,7 +2,7 @@
 # Print a version string.
 scriptversion=2018-08-31.20; # UTC
 
-# Copyright (C) 2012-2018 Red Hat, Inc.
+# Copyright (C) 2012-2019 Red Hat, Inc.
 # Copyright (C) 2007-2016 Free Software Foundation, Inc.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/build-aux/release.mk
+++ b/build-aux/release.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #          Federico Simoncelli <fsimon@kronosnet.org>

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/init/kronosnetd.default
+++ b/init/kronosnetd.default
@@ -1,6 +1,6 @@
 # kronosnetd startup options (see man kronosnetd.8)
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/init/kronosnetd.in
+++ b/init/kronosnetd.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/init/kronosnetd.service.in
+++ b/init/kronosnetd.service.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/kronosnet.spec.in
+++ b/kronosnet.spec.in
@@ -1,7 +1,7 @@
 ###############################################################################
 ###############################################################################
 ##
-##  Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+##  Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 ##
 ##  This copyrighted material is made available to anyone wishing to use,
 ##  modify, copy, or redistribute it subject to the terms and conditions

--- a/kronosnetd/Makefile.am
+++ b/kronosnetd/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/kronosnetd/cfg.c
+++ b/kronosnetd/cfg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/cfg.h
+++ b/kronosnetd/cfg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/etherfilter.c
+++ b/kronosnetd/etherfilter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/etherfilter.h
+++ b/kronosnetd/etherfilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/keygen.c
+++ b/kronosnetd/keygen.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/kronosnetd.logrotate.in
+++ b/kronosnetd/kronosnetd.logrotate.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/kronosnetd/logging.c
+++ b/kronosnetd/logging.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/logging.h
+++ b/kronosnetd/logging.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/main.c
+++ b/kronosnetd/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/vty.c
+++ b/kronosnetd/vty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/vty.h
+++ b/kronosnetd/vty.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/vty_auth.c
+++ b/kronosnetd/vty_auth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/vty_auth.h
+++ b/kronosnetd/vty_auth.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/vty_cli.c
+++ b/kronosnetd/vty_cli.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/vty_cli.h
+++ b/kronosnetd/vty_cli.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/vty_cli_cmds.c
+++ b/kronosnetd/vty_cli_cmds.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/kronosnetd/vty_cli_cmds.h
+++ b/kronosnetd/vty_cli_cmds.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/vty_utils.c
+++ b/kronosnetd/vty_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/kronosnetd/vty_utils.h
+++ b/kronosnetd/vty_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/common.c
+++ b/libknet/common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/common.h
+++ b/libknet/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/compat.c
+++ b/libknet/compat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Jan Friesse <jfriesse@redhat.com>
  *

--- a/libknet/compat.h
+++ b/libknet/compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Jan Friesse <jfriesse@redhat.com>
  *

--- a/libknet/compress.c
+++ b/libknet/compress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress.h
+++ b/libknet/compress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress_bzip2.c
+++ b/libknet/compress_bzip2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress_lz4.c
+++ b/libknet/compress_lz4.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress_lz4hc.c
+++ b/libknet/compress_lz4hc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress_lzma.c
+++ b/libknet/compress_lzma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress_lzo2.c
+++ b/libknet/compress_lzo2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress_model.h
+++ b/libknet/compress_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/compress_zlib.c
+++ b/libknet/compress_zlib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/crypto.c
+++ b/libknet/crypto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/crypto.h
+++ b/libknet/crypto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/crypto_model.h
+++ b/libknet/crypto_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/crypto_nss.c
+++ b/libknet/crypto_nss.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/host.c
+++ b/libknet/host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/host.h
+++ b/libknet/host.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>
@@ -19,7 +19,7 @@
 /**
  * @file libknet.h
  * @brief kronosnet API include file
- * @copyright Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * @copyright Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Kronosnet is an advanced VPN system for High Availability applications.
  */

--- a/libknet/libknet.pc.in
+++ b/libknet/libknet.pc.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Federico Simoncelli <fsimon@kronosnet.org>
 #

--- a/libknet/libknet_exported_syms
+++ b/libknet/libknet_exported_syms
@@ -1,6 +1,6 @@
 # Version and symbol export for libknet.so
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libknet/links.c
+++ b/libknet/links.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/links.c
+++ b/libknet/links.c
@@ -119,6 +119,12 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 		return -1;
 	}
 
+	if (dst_addr && (src_addr->ss_family != dst_addr->ss_family)) {
+		log_err(knet_h, KNET_SUB_LINK, "Source address family does not match destination address family");
+		errno = EINVAL;
+		return -1;
+	}
+
 	if (transport >= KNET_MAX_TRANSPORTS) {
 		errno = EINVAL;
 		return -1;

--- a/libknet/links.h
+++ b/libknet/links.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/links_acl.c
+++ b/libknet/links_acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/links_acl.h
+++ b/libknet/links_acl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/links_acl_ip.c
+++ b/libknet/links_acl_ip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/links_acl_ip.h
+++ b/libknet/links_acl_ip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/links_acl_loopback.c
+++ b/libknet/links_acl_loopback.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/links_acl_loopback.h
+++ b/libknet/links_acl_loopback.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/logging.c
+++ b/libknet/logging.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/logging.h
+++ b/libknet/logging.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/netutils.c
+++ b/libknet/netutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/netutils.h
+++ b/libknet/netutils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/onwire.h
+++ b/libknet/onwire.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/tests/Makefile.am
+++ b/libknet/tests/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
 #
 # Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libknet/tests/api-check.mk
+++ b/libknet/tests/api-check.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
 #
 # Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libknet/tests/api-test-coverage
+++ b/libknet/tests/api-test-coverage
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libknet/tests/api_knet_addrtostr.c
+++ b/libknet/tests/api_knet_addrtostr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/tests/api_knet_get_compress_list.c
+++ b/libknet/tests/api_knet_get_compress_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_get_crypto_list.c
+++ b/libknet/tests/api_knet_get_crypto_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_get_transport_id_by_name.c
+++ b/libknet/tests/api_knet_get_transport_id_by_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_get_transport_list.c
+++ b/libknet/tests/api_knet_get_transport_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_get_transport_name_by_id.c
+++ b/libknet/tests/api_knet_get_transport_name_by_id.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_add_datafd.c
+++ b/libknet/tests/api_knet_handle_add_datafd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_clear_stats.c
+++ b/libknet/tests/api_knet_handle_clear_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_compress.c
+++ b/libknet/tests/api_knet_handle_compress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_crypto.c
+++ b/libknet/tests/api_knet_handle_crypto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_enable_access_lists.c
+++ b/libknet/tests/api_knet_handle_enable_access_lists.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_enable_filter.c
+++ b/libknet/tests/api_knet_handle_enable_filter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_enable_pmtud_notify.c
+++ b/libknet/tests/api_knet_handle_enable_pmtud_notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_enable_sock_notify.c
+++ b/libknet/tests/api_knet_handle_enable_sock_notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_free.c
+++ b/libknet/tests/api_knet_handle_free.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_get_channel.c
+++ b/libknet/tests/api_knet_handle_get_channel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_get_datafd.c
+++ b/libknet/tests/api_knet_handle_get_datafd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_get_stats.c
+++ b/libknet/tests/api_knet_handle_get_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_get_threads_timer_res.c
+++ b/libknet/tests/api_knet_handle_get_threads_timer_res.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) -2019 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_get_transport_reconnect_interval.c
+++ b/libknet/tests/api_knet_handle_get_transport_reconnect_interval.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_new.c
+++ b/libknet/tests/api_knet_handle_new.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_new_limit.c
+++ b/libknet/tests/api_knet_handle_new_limit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_pmtud_get.c
+++ b/libknet/tests/api_knet_handle_pmtud_get.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_pmtud_getfreq.c
+++ b/libknet/tests/api_knet_handle_pmtud_getfreq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_pmtud_setfreq.c
+++ b/libknet/tests/api_knet_handle_pmtud_setfreq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_remove_datafd.c
+++ b/libknet/tests/api_knet_handle_remove_datafd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_set_threads_timer_res.c
+++ b/libknet/tests/api_knet_handle_set_threads_timer_res.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_set_transport_reconnect_interval.c
+++ b/libknet/tests/api_knet_handle_set_transport_reconnect_interval.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_handle_setfwd.c
+++ b/libknet/tests/api_knet_handle_setfwd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_add.c
+++ b/libknet/tests/api_knet_host_add.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_enable_status_change_notify.c
+++ b/libknet/tests/api_knet_host_enable_status_change_notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_get_host_list.c
+++ b/libknet/tests/api_knet_host_get_host_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_get_id_by_host_name.c
+++ b/libknet/tests/api_knet_host_get_id_by_host_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_get_name_by_host_id.c
+++ b/libknet/tests/api_knet_host_get_name_by_host_id.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_get_policy.c
+++ b/libknet/tests/api_knet_host_get_policy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_get_status.c
+++ b/libknet/tests/api_knet_host_get_status.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_remove.c
+++ b/libknet/tests/api_knet_host_remove.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_set_name.c
+++ b/libknet/tests/api_knet_host_set_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_host_set_policy.c
+++ b/libknet/tests/api_knet_host_set_policy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_add_acl.c
+++ b/libknet/tests/api_knet_link_add_acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_clear_acl.c
+++ b/libknet/tests/api_knet_link_clear_acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_clear_config.c
+++ b/libknet/tests/api_knet_link_clear_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_enable_status_change_notify.c
+++ b/libknet/tests/api_knet_link_enable_status_change_notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_get_config.c
+++ b/libknet/tests/api_knet_link_get_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_get_enable.c
+++ b/libknet/tests/api_knet_link_get_enable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_get_link_list.c
+++ b/libknet/tests/api_knet_link_get_link_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_get_ping_timers.c
+++ b/libknet/tests/api_knet_link_get_ping_timers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_get_pong_count.c
+++ b/libknet/tests/api_knet_link_get_pong_count.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_get_priority.c
+++ b/libknet/tests/api_knet_link_get_priority.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_get_status.c
+++ b/libknet/tests/api_knet_link_get_status.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_insert_acl.c
+++ b/libknet/tests/api_knet_link_insert_acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_rm_acl.c
+++ b/libknet/tests/api_knet_link_rm_acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_set_config.c
+++ b/libknet/tests/api_knet_link_set_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_set_config.c
+++ b/libknet/tests/api_knet_link_set_config.c
@@ -113,6 +113,24 @@ static void test(void)
 
 	flush_logs(logfds[0], stdout);
 
+	printf("Test knet_link_set_config with conflicting address families\n");
+
+	if (make_local_sockaddr6(&dst, 1) < 0) {
+		printf("Unable to convert dst to sockaddr: %s\n", strerror(errno));
+		exit(FAIL);
+	}
+
+	if (knet_link_set_config(knet_h, 1, 0, KNET_TRANSPORT_UDP, &src, &dst, 0) == 0) {
+		printf("knet_link_set_config accepted invalid address families: %s\n", strerror(errno));
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
 	printf("Test knet_link_set_config with dynamic dst_addr\n");
 
 	if (knet_link_set_config(knet_h, 1, 0, KNET_TRANSPORT_UDP, &src, NULL, 0) < 0) {
@@ -226,6 +244,11 @@ static void test(void)
 	}
 
 	printf("Test knet_link_set_config with static dst_addr\n");
+
+	if (make_local_sockaddr(&dst, 1) < 0) {
+		printf("Unable to convert dst to sockaddr: %s\n", strerror(errno));
+		exit(FAIL);
+	}
 
 	if (knet_link_set_config(knet_h, 1, 0, KNET_TRANSPORT_UDP, &src, &dst, 0) < 0) {
 		printf("Unable to configure link: %s\n", strerror(errno));

--- a/libknet/tests/api_knet_link_set_enable.c
+++ b/libknet/tests/api_knet_link_set_enable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_set_ping_timers.c
+++ b/libknet/tests/api_knet_link_set_ping_timers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_set_pong_count.c
+++ b/libknet/tests/api_knet_link_set_pong_count.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_link_set_priority.c
+++ b/libknet/tests/api_knet_link_set_priority.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_log_get_loglevel.c
+++ b/libknet/tests/api_knet_log_get_loglevel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_log_get_loglevel_id.c
+++ b/libknet/tests/api_knet_log_get_loglevel_id.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_log_get_loglevel_name.c
+++ b/libknet/tests/api_knet_log_get_loglevel_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_log_get_subsystem_id.c
+++ b/libknet/tests/api_knet_log_get_subsystem_id.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_log_get_subsystem_name.c
+++ b/libknet/tests/api_knet_log_get_subsystem_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_log_set_loglevel.c
+++ b/libknet/tests/api_knet_log_set_loglevel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_recv.c
+++ b/libknet/tests/api_knet_recv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_send.c
+++ b/libknet/tests/api_knet_send.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_send_compress.c
+++ b/libknet/tests/api_knet_send_compress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_send_crypto.c
+++ b/libknet/tests/api_knet_send_crypto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_send_loopback.c
+++ b/libknet/tests/api_knet_send_loopback.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_send_sync.c
+++ b/libknet/tests/api_knet_send_sync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/api_knet_strtoaddr.c
+++ b/libknet/tests/api_knet_strtoaddr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/tests/int_links_acl_ip.c
+++ b/libknet/tests/int_links_acl_ip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/tests/int_timediff.c
+++ b/libknet/tests/int_timediff.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/tests/knet_bench.c
+++ b/libknet/tests/knet_bench.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/pckt_test.c
+++ b/libknet/tests/pckt_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2015-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/tests/test-common.h
+++ b/libknet/tests/test-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/threads_common.c
+++ b/libknet/threads_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_common.h
+++ b/libknet/threads_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_dsthandler.c
+++ b/libknet/threads_dsthandler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2015-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_dsthandler.h
+++ b/libknet/threads_dsthandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2015-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_heartbeat.h
+++ b/libknet/threads_heartbeat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2015-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_pmtud.h
+++ b/libknet/threads_pmtud.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_rx.h
+++ b/libknet/threads_rx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/threads_tx.h
+++ b/libknet/threads_tx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2012-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *          Federico Simoncelli <fsimon@kronosnet.org>

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/transport_common.h
+++ b/libknet/transport_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/transport_loopback.c
+++ b/libknet/transport_loopback.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/transport_loopback.h
+++ b/libknet/transport_loopback.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/transport_sctp.h
+++ b/libknet/transport_sctp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Christine Caulfield <ccaulfie@redhat.com>
  *

--- a/libknet/transport_udp.h
+++ b/libknet/transport_udp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/transports.c
+++ b/libknet/transports.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libknet/transports.h
+++ b/libknet/transports.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/Makefile.am
+++ b/libnozzle/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libnozzle/internals.c
+++ b/libnozzle/internals.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/internals.h
+++ b/libnozzle/internals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/libnozzle.c
+++ b/libnozzle/libnozzle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/libnozzle.h
+++ b/libnozzle/libnozzle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *
@@ -16,7 +16,7 @@
  *
  * @file libnozzle.h
  * @brief tap interfaces management API include file
- * @copyright Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * @copyright Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * nozzle is a commodity library to manage tap (ethernet) interfaces
  */

--- a/libnozzle/libnozzle.pc.in
+++ b/libnozzle/libnozzle.pc.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libnozzle/libnozzle_exported_syms
+++ b/libnozzle/libnozzle_exported_syms
@@ -1,6 +1,6 @@
 # Version and symbol export for libnozzle.so
 #
-# Copyright (C) 2011-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2011-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libnozzle/tests/Makefile.am
+++ b/libnozzle/tests/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libnozzle/tests/api-test-coverage
+++ b/libnozzle/tests/api-test-coverage
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libnozzle/tests/api_nozzle_add_ip.c
+++ b/libnozzle/tests/api_nozzle_add_ip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_close.c
+++ b/libnozzle/tests/api_nozzle_close.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_del_ip.c
+++ b/libnozzle/tests/api_nozzle_del_ip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_get_fd.c
+++ b/libnozzle/tests/api_nozzle_get_fd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_get_handle_by_name.c
+++ b/libnozzle/tests/api_nozzle_get_handle_by_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_get_ips.c
+++ b/libnozzle/tests/api_nozzle_get_ips.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_get_mac.c
+++ b/libnozzle/tests/api_nozzle_get_mac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_get_mtu.c
+++ b/libnozzle/tests/api_nozzle_get_mtu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_get_name_by_handle.c
+++ b/libnozzle/tests/api_nozzle_get_name_by_handle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_open.c
+++ b/libnozzle/tests/api_nozzle_open.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_run_updown.c
+++ b/libnozzle/tests/api_nozzle_run_updown.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_set_down.c
+++ b/libnozzle/tests/api_nozzle_set_down.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_set_mac.c
+++ b/libnozzle/tests/api_nozzle_set_mac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_set_mtu.c
+++ b/libnozzle/tests/api_nozzle_set_mtu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/api_nozzle_set_up.c
+++ b/libnozzle/tests/api_nozzle_set_up.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/int_execute_bin_sh_command.c
+++ b/libnozzle/tests/int_execute_bin_sh_command.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/nozzle_run_updown_exit_false
+++ b/libnozzle/tests/nozzle_run_updown_exit_false
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libnozzle/tests/nozzle_run_updown_exit_true
+++ b/libnozzle/tests/nozzle_run_updown_exit_true
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2010-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2010-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/libnozzle/tests/test-common.c
+++ b/libnozzle/tests/test-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/libnozzle/tests/test-common.h
+++ b/libnozzle/tests/test-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2018-2019 Red Hat, Inc.  All rights reserved.
  *
  * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *

--- a/man/Doxyfile-knet.in
+++ b/man/Doxyfile-knet.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #         Christine Caulfield <ccaulfie@redhat.com>

--- a/man/Doxyfile-nozzle.in
+++ b/man/Doxyfile-nozzle.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #         Christine Caulfield <ccaulfie@redhat.com>

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
 #
 # Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #          Federico Simoncelli <fsimon@kronosnet.org>

--- a/man/api-to-man-page-coverage
+++ b/man/api-to-man-page-coverage
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/man/knet-keygen.8
+++ b/man/knet-keygen.8
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (C) 2012-2018 Red Hat, Inc.
+.\" * Copyright (C) 2012-2019 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *

--- a/man/kronosnetd.8
+++ b/man/kronosnetd.8
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (C) 2012-2018 Red Hat, Inc.
+.\" * Copyright (C) 2012-2019 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *

--- a/poc-code/Makefile.am
+++ b/poc-code/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/poc-code/iov-hash/Makefile.am
+++ b/poc-code/iov-hash/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+# Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
 #
 # Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
 #

--- a/poc-code/iov-hash/main.c
+++ b/poc-code/iov-hash/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Red Hat, Inc.  All rights reserved.
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
  *
  * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
  *


### PR DESCRIPTION
We can't create a link with a source address of a different
address family than the destination as all sends will fail.