### PR TITLE
crypto: reduce minimum key size to 1024bit

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -673,8 +673,7 @@ int knet_handle_pmtud_get(knet_handle_t knet_h,
 				unsigned int *data_mtu);
 
 
-
-#define KNET_MIN_KEY_LEN  256
+#define KNET_MIN_KEY_LEN  128
 #define KNET_MAX_KEY_LEN 4096
 
 struct knet_handle_crypto_cfg {


### PR DESCRIPTION
Corosync 2.x uses 1024 bit keys, libknet originally supported a range of
1024-4096 bytes, which probably means that this incompatibility is
simply an artifact of confusing bits and bytes.

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>