### PR TITLE
man: Tidy manpages

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -161,6 +161,7 @@ int knet_handle_free(knet_handle_t knet_h);
 
 /**
  * knet_handle_set_threads_timer_res
+ *
  * @brief Change internal thread timer resolution
  *
  * knet_h   - pointer to knet_handle_t
@@ -195,6 +196,7 @@ int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
 
 /**
  * knet_handle_get_threads_timer_res
+ *
  * @brief Get internal thread timer resolutions
  *
  * knet_h   - pointer to knet_handle_t
@@ -322,6 +324,7 @@ int knet_handle_add_datafd(knet_handle_t knet_h, int *datafd, int8_t *channel);
 
 /**
  * knet_handle_remove_datafd
+ *
  * @brief Remove a file descriptor from knet
  *
  * knet_h   - pointer to knet_handle_t
@@ -340,6 +343,7 @@ int knet_handle_remove_datafd(knet_handle_t knet_h, int datafd);
 
 /**
  * knet_handle_get_channel
+ *
  * @brief Get the channel associated with a file descriptor
  *
  * knet_h  - pointer to knet_handle_t
@@ -360,6 +364,7 @@ int knet_handle_get_channel(knet_handle_t knet_h, const int datafd, int8_t *chan
 
 /**
  * knet_handle_get_datafd
+ *
  * @brief Get the file descriptor associated with a channel
  *
  * knet_h   - pointer to knet_handle_t

--- a/libnozzle/libnozzle.h
+++ b/libnozzle/libnozzle.h
@@ -25,6 +25,7 @@ typedef struct nozzle_iface *nozzle_t;
 
 /**
  * nozzle_open
+ *
  * @brief create a new tap device on the system.
  *
  * devname - pointer to device name of at least size IFNAMSIZ.
@@ -55,6 +56,7 @@ nozzle_t nozzle_open(char *devname, size_t devname_size, const char *updownpath)
 
 /**
  * nozzle_close
+ *
  * @brief deconfigure and destroy a nozzle device
  *
  * nozzle - pointer to the nozzle struct to destroy
@@ -74,9 +76,8 @@ int nozzle_close(nozzle_t nozzle);
 
 /**
  * nozzle_run_updown
- * @brief execute updown commands associated with a nozzle device. It is
- *        the application responsibility to call helper scripts
- *        before or after creating/destroying interfaces or IP addresses.
+ *
+ * @brief execute updown commands associated with a nozzle device.
  *
  * nozzle - pointer to the nozzle struct
  *
@@ -85,6 +86,9 @@ int nozzle_close(nozzle_t nozzle);
  * exec_string - pointers to string to record executing action stdout/stderr.
  *               The string is malloc'ed, the caller needs to free the buffer.
  *               If the script generates no output this string might be NULL.
+ *
+ * It is the application responsibility to call helper scripts
+ * before or after creating/destroying interfaces or IP addresses.
  *
  * @return
  * 0 on success
@@ -96,6 +100,7 @@ int nozzle_run_updown(const nozzle_t nozzle, uint8_t action, char **exec_string)
 
 /**
  * nozzle_set_up
+ *
  * @brief equivalent of ifconfig up
  *
  * nozzle - pointer to the nozzle struct
@@ -109,6 +114,7 @@ int nozzle_set_up(nozzle_t nozzle);
 
 /**
  * nozzle_set_down
+ *
  * @brief equivalent of ifconfig down
  *
  * nozzle - pointer to the nozzle struct
@@ -122,6 +128,7 @@ int nozzle_set_down(nozzle_t nozzle);
 
 /**
  * nozzle_add_ip
+ *
  * @brief equivalent of ip addr or ifconfig <ipaddress/prefix>
  *
  * nozzle - pointer to the nozzle struct
@@ -142,6 +149,7 @@ int nozzle_add_ip(nozzle_t nozzle, const char *ipaddr, const char *prefix);
 
 /**
  * nozzle_del_ip
+ *
  * @brief equivalent of ip addr del or ifconfig del <ipaddress/prefix>
  *
  * nozzle - pointer to the nozzle struct
@@ -170,6 +178,7 @@ struct nozzle_ip {
 
 /**
  * nozzle_get_ips
+ *
  * @brief retrieve the list of all configured ips for a given interface
  *
  * nozzle - pointer to the nozzle struct
@@ -191,6 +200,7 @@ int nozzle_get_ips(const nozzle_t nozzle, struct nozzle_ip **nozzle_ip);
 
 /**
  * nozzle_get_mtu
+ *
  * @brief retrieve mtu on a given nozzle interface
  *
  * nozzle - pointer to the nozzle struct
@@ -204,6 +214,7 @@ int nozzle_get_mtu(const nozzle_t nozzle);
 
 /**
  * nozzle_set_mtu
+ *
  * @brief set mtu on a given nozzle interface
  *
  * nozzle - pointer to the nozzle struct
@@ -219,6 +230,7 @@ int nozzle_set_mtu(nozzle_t nozzle, const int mtu);
 
 /**
  * nozzle_reset_mtu
+ *
  * @brief reset mtu on a given nozzle interface to the system default
  *
  * nozzle - pointer to the nozzle struct
@@ -232,6 +244,7 @@ int nozzle_reset_mtu(nozzle_t nozzle);
 
 /**
  * nozzle_get_mac
+ *
  * @brief retrieve mac address on a given nozzle interface
  *
  * nozzle - pointer to the nozzle struct
@@ -247,6 +260,7 @@ int nozzle_get_mac(const nozzle_t nozzle, char **ether_addr);
 
 /**
  * nozzle_set_mac
+ *
  * @brief set mac address on a given nozzle interface
  *
  * nozzle - pointer to the nozzle struct
@@ -262,6 +276,7 @@ int nozzle_set_mac(nozzle_t nozzle, const char *ether_addr);
 
 /**
  * nozzle_reset_mac
+ *
  * @brief reset mac address on a given nozzle interface to system default
  *
  * nozzle - pointer to the nozzle struct
@@ -275,6 +290,7 @@ int nozzle_reset_mac(nozzle_t nozzle);
 
 /**
  * nozzle_get_handle_by_name
+ *
  * @brief find a nozzle handle by device name
  *
  * devname - string containing the name of the interface
@@ -288,6 +304,7 @@ nozzle_t nozzle_get_handle_by_name(const char *devname);
 
 /**
  * nozzle_get_name_by_handle
+ *
  * @brief retrieve nozzle interface name by handle
  *
  * nozzle - pointer to the nozzle struct
@@ -301,6 +318,7 @@ const char *nozzle_get_name_by_handle(const nozzle_t nozzle);
 
 /**
  * nozzle_get_fd
+ *
  * @brief
  *
  * nozzle - pointer to the nozzle struct

--- a/man/doxyxml.c
+++ b/man/doxyxml.c
@@ -332,19 +332,25 @@ static int read_structure_from_xml(char *refid, char *name)
 
 static void print_param(FILE *manfile, struct param_info *pi, int field_width, int bold, const char *delimiter)
 {
-	char asterisk = ' ';
+	char *asterisks = "  ";
 	char *type = pi->paramtype;
 
 	/* Reformat pointer params so they look nicer */
 	if (pi->paramtype[strlen(pi->paramtype)-1] == '*') {
-		asterisk='*';
+		asterisks=" *";
 		type = strdup(pi->paramtype);
 		type[strlen(type)-1] = '\0';
+
+		/* Cope with double pointers */
+		if (pi->paramtype[strlen(type)-1] == '*') {
+			asterisks="**";
+			type[strlen(type)-1] = '\0';
+		}
 	}
 
-	fprintf(manfile, "    %s%-*s%c%s\\fI%s\\fP%s\n",
+	fprintf(manfile, "    %s%-*s%s%s\\fI%s\\fP%s\n",
 		bold?"\\fB":"", field_width, type,
-		asterisk, bold?"\\fP":"", pi->paramname, delimiter);
+		asterisks, bold?"\\fP":"", pi->paramname, delimiter);
 
 	if (type != pi->paramtype) {
 		free(type);
@@ -559,11 +565,6 @@ static void print_manpage(char *name, char *def, char *brief, char *args, char *
 
 		map_iter = qb_map_iter_create(used_structures_map);
 		for (p = qb_map_iter_next(map_iter, &data); p; p = qb_map_iter_next(map_iter, &data)) {
-			fprintf(manfile, ".SS \"\"\n");
-			fprintf(manfile, ".PP\n");
-			fprintf(manfile, ".sp\n");
-			fprintf(manfile, ".sp\n");
-			fprintf(manfile, ".RS\n");
 			fprintf(manfile, ".nf\n");
 			fprintf(manfile, "\\fB\n");
 

--- a/man/doxyxml.c
+++ b/man/doxyxml.c
@@ -34,6 +34,14 @@
 #define XML_DIR "../man/xml-knet"
 #define XML_FILE "libknet_8h.xml"
 
+/*
+ * This isn't a maximum size, it just defines how long a parameter
+ * type can get before we decide it's not worth lining everything up to.
+ * it's mainly to stop function pointer types (which can get VERY long because
+ * of all *their* parameters) making everything else 'line-up' over separate lines
+ */
+#define LINE_LENGTH 80
+
 static int print_ascii = 1;
 static int print_man = 0;
 static int print_params = 0;
@@ -510,7 +518,8 @@ static void print_manpage(char *name, char *def, char *brief, char *args, char *
 	qb_list_for_each(iter, &params_list) {
 		pi = qb_list_entry(iter, struct param_info, list);
 
-		if (strlen(pi->paramtype) > max_param_type_len) {
+		if ((strlen(pi->paramtype) < LINE_LENGTH) &&
+		    (strlen(pi->paramtype) > max_param_type_len)) {
 			max_param_type_len = strlen(pi->paramtype);
 		}
 		if (strlen(pi->paramname) > max_param_name_len) {


### PR DESCRIPTION
doxygen works in mysterious ways, adding a blank line before
@brief makes the lines following that much tidier.

So now instead of

nozzle_close nozzle - pointer to the nozzle struct to destroy

we get:

nozzle_close

       nozzle - pointer to the nozzle struct to destroy