### PR TITLE
misc: some coverity fixes

### DIFF
--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -784,7 +784,7 @@ int knet_handle_enable_sock_notify(knet_handle_t knet_h,
 						int error,
 						int errorno))
 {
-	int savederrno = 0, err = 0;
+	int savederrno = 0;
 
 	if (!knet_h) {
 		errno = EINVAL;
@@ -810,8 +810,7 @@ int knet_handle_enable_sock_notify(knet_handle_t knet_h,
 
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
 
-	errno = err ? savederrno : 0;
-	return err;
+	return 0;
 }
 
 int knet_handle_add_datafd(knet_handle_t knet_h, int *datafd, int8_t *channel)
@@ -1575,7 +1574,6 @@ out_unlock:
 int knet_handle_get_stats(knet_handle_t knet_h, struct knet_handle_stats *stats, size_t struct_size)
 {
 	int savederrno = 0;
-	int err = 0;
 
 	if (!knet_h) {
 		errno = EINVAL;
@@ -1615,14 +1613,12 @@ int knet_handle_get_stats(knet_handle_t knet_h, struct knet_handle_stats *stats,
 	stats->size = sizeof(struct knet_handle_stats);
 
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
-	errno = err ? savederrno : 0;
-	return err;
+	return 0;
 }
 
 int knet_handle_clear_stats(knet_handle_t knet_h, int clear_option)
 {
 	int savederrno = 0;
-	int err = 0;
 
 	if (!knet_h) {
 		errno = EINVAL;
@@ -1650,8 +1646,7 @@ int knet_handle_clear_stats(knet_handle_t knet_h, int clear_option)
 	}
 
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
-	errno = err ? savederrno : 0;
-	return err;
+	return 0;
 }
 
 int knet_handle_set_threads_timer_res(knet_handle_t knet_h,

--- a/libknet/host.c
+++ b/libknet/host.c
@@ -331,7 +331,7 @@ int knet_host_get_id_by_host_name(knet_handle_t knet_h, const char *name,
 int knet_host_get_host_list(knet_handle_t knet_h,
 			    knet_node_id_t *host_ids, size_t *host_ids_entries)
 {
-	int savederrno = 0, err = 0;
+	int savederrno = 0;
 
 	if (!knet_h) {
 		errno = EINVAL;
@@ -355,8 +355,7 @@ int knet_host_get_host_list(knet_handle_t knet_h,
 	*host_ids_entries = knet_h->host_ids_entries;
 
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
-	errno = err ? savederrno : 0;
-	return err;
+	return 0;
 }
 
 int knet_host_set_policy(knet_handle_t knet_h, knet_node_id_t host_id,

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -380,13 +380,13 @@ static int _handle_check_pmtud(knet_handle_t knet_h, struct knet_host *dst_host,
 	struct timespec clock_now;
 	unsigned long long diff_pmtud, interval;
 
+	if (clock_gettime(CLOCK_MONOTONIC, &clock_now) != 0) {
+		log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get monotonic clock");
+		return 0;
+	}
+
 	if (!force_run) {
 		interval = knet_h->pmtud_interval * 1000000000llu; /* nanoseconds */
-
-		if (clock_gettime(CLOCK_MONOTONIC, &clock_now) != 0) {
-			log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get monotonic clock");
-			return 0;
-		}
 
 		timespec_diff(dst_link->pmtud_last, clock_now, &diff_pmtud);
 

--- a/libnozzle/internals.c
+++ b/libnozzle/internals.c
@@ -144,7 +144,7 @@ char *generate_v4_broadcast(const char *ipaddr, const char *prefix)
 
 	prefix_len = atoi(prefix);
 
-	if ((prefix_len > 32) || (prefix_len < 0))
+	if ((prefix_len > 32) || (prefix_len <= 0))
 		return NULL;
 
 	if (inet_pton(AF_INET, ipaddr, &address) <= 0)

--- a/libnozzle/libnozzle.c
+++ b/libnozzle/libnozzle.c
@@ -405,7 +405,8 @@ nozzle_t nozzle_open(char *devname, size_t devname_size, const char *updownpath)
 		return NULL;
 	}
 
-	if (strlen(devname) > IFNAMSIZ) {
+	/* Need to allow space for trailing NUL */
+	if (strlen(devname) >= IFNAMSIZ) {
 		errno = E2BIG;
 		return NULL;
 	}

--- a/libnozzle/tests/api_nozzle_run_updown.c
+++ b/libnozzle/tests/api_nozzle_run_updown.c
@@ -29,16 +29,21 @@ static int test(void)
 	nozzle_t nozzle = NULL;
 	char *error_string = NULL;
 	char *tmpdir = NULL;
-	char tmpdirsrc[PATH_MAX];
+	char tmpdirsrc[PATH_MAX*2];
 	char tmpstr[PATH_MAX*2];
 	char srcfile[PATH_MAX];
 	char dstfile[PATH_MAX];
+	char current_dir[PATH_MAX];
 
 	/*
 	 * create a tmp dir for storing up/down scripts.
 	 * we cannot create symlinks src dir
 	 */
-	strcpy(tmpdirsrc, ABSBUILDDIR "/nozzle_test_XXXXXX");
+	if (getcwd(current_dir, sizeof(current_dir)) == NULL) {
+		printf("Unable to get current working directory: %s\n", strerror(errno));
+		return -1;
+	}
+	snprintf(tmpdirsrc, sizeof(tmpdirsrc)-1, "%s/nozzle_test_XXXXXX", current_dir);
 
 	tmpdir = mkdtemp(tmpdirsrc);
 	if (!tmpdir) {

--- a/man/doxyxml.c
+++ b/man/doxyxml.c
@@ -695,17 +695,17 @@ static void collect_enums(xmlNode *cur_node, void *arg)
 				}
 			}
 
-			si = malloc(sizeof(struct struct_info));
-			if (si) {
-				si->kind = STRUCTINFO_ENUM;
-				qb_list_init(&si->params_list);
-				si->structname = strdup(name);
-				traverse_node(cur_node, "enumvalue", read_struct, si);
-				qb_map_put(structures_map, refid, si);
+			if (name) {
+				si = malloc(sizeof(struct struct_info));
+				if (si) {
+					si->kind = STRUCTINFO_ENUM;
+					qb_list_init(&si->params_list);
+					si->structname = strdup(name);
+					traverse_node(cur_node, "enumvalue", read_struct, si);
+					qb_map_put(structures_map, refid, si);
+				}
 			}
-
 		}
-
 	}
 }
 
@@ -786,7 +786,7 @@ static void traverse_members(xmlNode *cur_node, void *arg)
 		free(kind);
 		free(def);
 		free(args);
-//		free(name); /* don't free, it's in the map */
+		free(name);
 	}
 }
 


### PR DESCRIPTION
In rough order of seriousness:

1. Fix clock_gettime() in pmtud so that it's always called, as
   variable 'clock_now' is always read.
2. Allow space for trailing NUL in libnozzle device names
3. Fix api_nozzle_run_updown_test so it can run out of the build tree
4. Disallow a 0 length prefix in libnozzle
5. Fix potential use of NULL pointer on doxyxml
6. Free 'name' in doxyxml as it's *not* in the map any more
7. Fix dead code in libknet API functions left by code changes