### PR TITLE
misc: Fix more covscan warnings

### DIFF
--- a/libknet/common.c
+++ b/libknet/common.c
@@ -101,7 +101,7 @@ static void *open_lib(knet_handle_t knet_h, const char *libname, int extra_flags
 		}
 
 		if (S_ISLNK(sb.st_mode)) {
-			if (readlink(path, link, sizeof(link)) < 0) {
+			if (readlink(path, link, sizeof(link)-1) < 0) {
 				log_debug(knet_h, KNET_SUB_COMMON, "Unable to readlink %s: %s", path, strerror(errno));
 				goto out;
 			}

--- a/libknet/compress.c
+++ b/libknet/compress.c
@@ -359,11 +359,11 @@ void compress_fini(
 	}
 
 	while (compress_modules_cmds[idx].model_name != NULL) {
-		if ((compress_modules_cmds[idx].built_in == 1) &&
+		if ((idx < KNET_MAX_COMPRESS_METHODS) && /* check idx first so we don't read bad data */
+		    (compress_modules_cmds[idx].built_in == 1) &&
 		    (compress_modules_cmds[idx].loaded == 1) &&
 		    (compress_modules_cmds[idx].model_id > 0) &&
-		    (knet_h->compress_int_data[idx] != NULL) &&
-		    (idx < KNET_MAX_COMPRESS_METHODS)) {
+		    (knet_h->compress_int_data[idx] != NULL)) {
 			if ((all) || (compress_modules_cmds[idx].model_id == knet_h->compress_model)) {
 				if (compress_modules_cmds[idx].ops->fini != NULL) {
 					compress_modules_cmds[idx].ops->fini(knet_h, idx);

--- a/libknet/crypto.c
+++ b/libknet/crypto.c
@@ -129,7 +129,6 @@ int crypto_init(
 
 	if (!knet_h->crypto_instance) {
 		log_err(knet_h, KNET_SUB_CRYPTO, "Unable to allocate memory for crypto instance");
-		pthread_rwlock_unlock(&shlib_rwlock);
 		savederrno = ENOMEM;
 		goto out_err;
 	}

--- a/libknet/crypto_nss.c
+++ b/libknet/crypto_nss.c
@@ -761,7 +761,7 @@ static int nsscrypto_init(
 	knet_h->crypto_instance->model_instance = malloc(sizeof(struct nsscrypto_instance));
 	if (!knet_h->crypto_instance->model_instance) {
 		log_err(knet_h, KNET_SUB_NSSCRYPTO, "Unable to allocate memory for nss model instance");
-		savederrno = ENOMEM;
+		errno = ENOMEM;
 		return -1;
 	}
 

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -1653,7 +1653,6 @@ int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
 				      useconds_t timeres)
 {
 	int savederrno = 0;
-	int err = 0;
 
 	if (!knet_h) {
 		errno = EINVAL;
@@ -1687,15 +1686,13 @@ int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
 	}
 
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
-	errno = err ? savederrno : 0;
-	return err;
+	return 0;
 }
 
 int knet_handle_get_threads_timer_res(knet_handle_t knet_h,
 				      useconds_t *timeres)
 {
 	int savederrno = 0;
-	int err = 0;
 
 	if (!knet_h) {
 		errno = EINVAL;
@@ -1718,6 +1715,5 @@ int knet_handle_get_threads_timer_res(knet_handle_t knet_h,
 	*timeres = knet_h->threads_timer_res;
 
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
-	errno = err ? savederrno : 0;
-	return err;
+	return 0;
 }

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -44,7 +44,6 @@ static int _handle_check_link_pmtud(knet_handle_t knet_h, struct knet_host *dst_
 
 	mutex_retry_limit = 0;
 	failsafe = 0;
-	pad_len = 0;
 
 	dst_link->last_bad_mtu = 0;
 

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -500,7 +500,6 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 		} else { /* HOSTINFO */
 			knet_hostinfo = (struct knet_hostinfo *)inbuf->khp_data_userdata;
 			if (knet_hostinfo->khi_bcast == KNET_HOSTINFO_UCAST) {
-				bcast = 0;
 				knet_hostinfo->khi_dst_node_id = ntohs(knet_hostinfo->khi_dst_node_id);
 			}
 			if (!_seq_num_lookup(src_host, inbuf->khp_data_seq_num, 0, 0)) {

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -42,7 +42,6 @@ static int _dispatch_to_links(knet_handle_t knet_h, struct knet_host *dst_host, 
 	struct knet_link *cur_link;
 
 	for (link_idx = 0; link_idx < dst_host->active_link_entries; link_idx++) {
-		sent_msgs = 0;
 		prev_sent = 0;
 		progress = 1;
 

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -405,7 +405,7 @@ int _is_valid_fd(knet_handle_t knet_h, int sockfd)
 		return -1;
 	}
 
-	if (sockfd > KNET_MAX_FDS) {
+	if (sockfd >= KNET_MAX_FDS) {
 		errno = EINVAL;
 		return -1;
 	}
@@ -430,7 +430,7 @@ int _set_fd_tracker(knet_handle_t knet_h, int sockfd, uint8_t transport, uint8_t
 		return -1;
 	}
 
-	if (sockfd > KNET_MAX_FDS) {
+	if (sockfd >= KNET_MAX_FDS) {
 		errno = EINVAL;
 		return -1;
 	}

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -733,7 +733,6 @@ static void _handle_incoming_sctp(knet_handle_t knet_h, int listen_sock)
 	if (knet_h->use_access_lists) {
 		if (!check_validate(knet_h, listen_sock, KNET_TRANSPORT_SCTP, &ss)) {
 			savederrno = EINVAL;
-			err = -1;
 			log_debug(knet_h, KNET_SUB_TRANSP_SCTP, "Connection rejected from %s/%s", addr_str, port_str);
 			close(new_fd);
 			errno = savederrno;
@@ -871,6 +870,7 @@ static void _handle_listen_sctp_errors(knet_handle_t knet_h)
 			info->accepted_socks[i] = -1;
 			free(accept_info);
 			close(sockfd);
+			break; /* Keeps covscan happy */
 		}
 	}
 }

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -71,6 +71,7 @@ int udp_transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_lin
 		err = -1;
 		goto exit_error;
 	}
+	memset(info, 0, sizeof(udp_link_info_t));
 
 	sock = socket(kn_link->src_addr.ss_family, SOCK_DGRAM, 0);
 	if (sock < 0) {
@@ -363,7 +364,7 @@ static int read_errs_from_sock(knet_handle_t knet_h, int sockfd)
 						case SO_EE_ORIGIN_ICMP:  /* ICMP */
 						case SO_EE_ORIGIN_ICMP6: /* ICMP6 */
 							origin = (struct sockaddr_storage *)(void *)SO_EE_OFFENDER(sock_err);
-							if (knet_addrtostr(origin, sizeof(origin),
+							if (knet_addrtostr(origin, sizeof(*origin),
 									   addr_str, KNET_MAX_HOST_LEN,
 									   port_str, KNET_MAX_PORT_LEN) < 0) {
 								log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Received ICMP error from unknown source: %s", strerror(sock_err->ee_errno));


### PR DESCRIPTION
The only serious bug here is in transport_udp.c
(see bottom of patch), the rest are mostly detail. It's worth someone double/triple checking the change to transport_sctp.c

covscan still reports a lot of errors against doxyxml, most of
which are because it doesn't understand the libqb hashtables.