### PR TITLE
[crypto]openssl error strings release

### DIFF
--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -496,6 +496,10 @@ static void opensslcrypto_fini(
 		crypto_instance->model_instance = NULL;
 	}
 
+#ifdef BUILDCRYPTOOPENSSL10
+	ERR_free_strings();
+#endif
+
 	return;
 }
 


### PR DESCRIPTION
In versions prior to OpenSSL 1.1.0, ERR_free_strings() releases
any resources created by ERR_load_crypto_strings.

Signed-off-by: yuan ren <yren@suse.com>