### PR TITLE
[compress]Default compress level use

### DIFF
--- a/build-aux/knet_valgrind_memcheck.supp
+++ b/build-aux/knet_valgrind_memcheck.supp
@@ -759,3 +759,83 @@
    fun:_dlerror_run
    fun:dlopen@@GLIBC_2.2.5
 }
+{
+   Opensuse tumbleweed libnss
+   Memcheck:Cond
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_generate
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_instantiate
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_get0_public
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:encrypt_openssl
+   fun:opensslcrypto_encrypt_and_signv
+   fun:opensslcrypto_encrypt_and_sign
+   fun:_handle_check_each
+   fun:_send_pings
+   fun:_handle_heartbt_thread
+   fun:start_thread
+}
+{
+   Opensuse tumbleweed libnss
+   Memcheck:Cond
+   obj:/usr/lib64/libcrypto.so.1.1
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_generate
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_instantiate
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_get0_public
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:encrypt_openssl
+   fun:opensslcrypto_encrypt_and_signv
+   fun:opensslcrypto_encrypt_and_sign
+   fun:_handle_check_each
+   fun:_send_pings
+   fun:_handle_heartbt_thread
+}
+{
+   Opensuse tumbleweed libnss
+   Memcheck:Cond
+   obj:/usr/lib64/libcrypto.so.1.1
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_generate
+   fun:RAND_DRBG_bytes
+   fun:encrypt_openssl
+   fun:opensslcrypto_encrypt_and_signv
+   fun:opensslcrypto_encrypt_and_sign
+   fun:_handle_check_each
+   fun:_send_pings
+   fun:_handle_heartbt_thread
+   fun:start_thread
+   fun:clone
+}
+{
+   Opensuse tumbleweed libnss
+   Memcheck:Cond
+   obj:/usr/lib64/libcrypto.so.1.1
+   fun:RAND_DRBG_generate
+   fun:RAND_DRBG_bytes
+   fun:encrypt_openssl
+   fun:opensslcrypto_encrypt_and_signv
+   fun:opensslcrypto_encrypt_and_sign
+   fun:_handle_check_each
+   fun:_send_pings
+   fun:_handle_heartbt_thread
+   fun:start_thread
+   fun:clone
+}
+{
+   Opensuse tumbleweed libnss
+   Memcheck:Param
+   sendmsg(msg.msg_iov[0])
+   fun:sendmsg
+   fun:_sendmmsg
+   fun:_dispatch_to_links
+   fun:_parse_recv_from_sock
+   fun:_handle_send_to_links
+   fun:_handle_send_to_links_thread
+   fun:start_thread
+   fun:clone
+}

--- a/libknet/compress_bzip2.c
+++ b/libknet/compress_bzip2.c
@@ -15,6 +15,12 @@
 #include "logging.h"
 #include "compress_model.h"
 
+#ifdef BZIP2_COMPRESS_LEVEL
+#define KNET_COMPRESS_DEFAULT BZIP2_COMPRESS_LEVEL
+#else
+#define KNET_COMPRESS_DEFAULT KNET_COMPRESS_UNKNOWN_DEFAULT
+#endif
+
 static int bzip2_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -103,6 +109,11 @@ static int bzip2_decompress(
 	return err;
 }
 
+static int bzip2_get_default_level()
+{
+	return KNET_COMPRESS_DEFAULT;
+}
+
 compress_ops_t compress_model = {
 	KNET_COMPRESS_MODEL_ABI,
 	NULL,
@@ -110,5 +121,6 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	bzip2_compress,
-	bzip2_decompress
+	bzip2_decompress,
+	bzip2_get_default_level
 };

--- a/libknet/compress_lz4.c
+++ b/libknet/compress_lz4.c
@@ -6,6 +6,7 @@
  * This software licensed under LGPL-2.0+
  */
 #define KNET_MODULE
+#define ACCELERATION_DEFAULT 1 /* lz4 default compression level from lz4.c */
 
 #include "config.h"
 
@@ -14,6 +15,12 @@
 
 #include "logging.h"
 #include "compress_model.h"
+
+#ifdef LZ4_COMPRESS_DEFAULT
+#define KNET_COMPRESS_DEFAULT LZ4_COMPRESS_DEFAULT
+#else
+#define KNET_COMPRESS_DEFAULT KNET_COMPRESS_UNKNOWN_DEFAULT
+#endif
 
 static int lz4_compress(
 	knet_handle_t knet_h,
@@ -80,6 +87,11 @@ static int lz4_decompress(
 	return err;
 }
 
+static int lz4_get_default_level()
+{
+	return KNET_COMPRESS_DEFAULT;
+}
+
 compress_ops_t compress_model = {
 	KNET_COMPRESS_MODEL_ABI,
 	NULL,
@@ -87,5 +99,6 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	lz4_compress,
-	lz4_decompress
+	lz4_decompress,
+	lz4_get_default_level
 };

--- a/libknet/compress_lz4hc.c
+++ b/libknet/compress_lz4hc.c
@@ -16,6 +16,11 @@
 #include "logging.h"
 #include "compress_model.h"
 
+#ifdef LZ4HC_CLEVEL_DEFAULT
+#define KNET_COMPRESS_DEFAULT LZ4HC_CLEVEL_DEFAULT /* lz4hc default compression level from lz4hc.h */
+#else
+#define KNET_COMPRESS_DEFAULT KNET_COMPRESS_UNKNOWN_DEFAULT
+#endif
 #ifdef LZ4HC_CLEVEL_MAX
 #define KNET_LZ4HC_MAX LZ4HC_CLEVEL_MAX
 #endif
@@ -91,6 +96,11 @@ static int lz4_decompress(
 	return err;
 }
 
+static int lz4hc_get_default_level()
+{
+	return KNET_COMPRESS_DEFAULT;
+}
+
 compress_ops_t compress_model = {
 	KNET_COMPRESS_MODEL_ABI,
 	NULL,
@@ -98,5 +108,6 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	lz4hc_compress,
-	lz4_decompress
+	lz4_decompress,
+	lz4hc_get_default_level
 };

--- a/libknet/compress_lzma.c
+++ b/libknet/compress_lzma.c
@@ -15,6 +15,12 @@
 #include "logging.h"
 #include "compress_model.h"
 
+#ifdef LZMA_PRESET_DEFAULT
+#define KNET_COMPRESS_DEFAULT LZMA_PRESET_DEFAULT /* lzma default compression level from lzma.h */
+#else
+#define KNET_COMPRESS_DEFAULT KNET_COMPRESS_UNKNOWN_DEFAULT
+#endif
+
 static int lzma_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -114,6 +120,11 @@ static int lzma_decompress(
 	return err;
 }
 
+static int lzma_get_default_level()
+{
+	return KNET_COMPRESS_DEFAULT;
+}
+
 compress_ops_t compress_model = {
 	KNET_COMPRESS_MODEL_ABI,
 	NULL,
@@ -121,5 +132,6 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	lzma_compress,
-	lzma_decompress
+	lzma_decompress,
+	lzma_get_default_level
 };

--- a/libknet/compress_lzo2.c
+++ b/libknet/compress_lzo2.c
@@ -6,6 +6,7 @@
  * This software licensed under LGPL-2.0+
  */
 #define KNET_MODULE
+#define LZO2_COMPRESS_DEFAULT 1
 
 #include "config.h"
 
@@ -16,6 +17,12 @@
 
 #include "logging.h"
 #include "compress_model.h"
+
+#ifdef LZO2_COMPRESS_DEFAULT
+#define KNET_COMPRESS_DEFAULT LZO2_COMPRESS_DEFAULT
+#else
+#define KNET_COMPRESS_DEFAULT KNET_COMPRESS_UNKNOWN_DEFAULT
+#endif
 
 static int lzo2_is_init(
 	knet_handle_t knet_h,
@@ -154,6 +161,11 @@ static int lzo2_decompress(
 	return err;
 }
 
+static int lzo2_get_default_level()
+{
+	return KNET_COMPRESS_DEFAULT;
+}
+
 compress_ops_t compress_model = {
 	KNET_COMPRESS_MODEL_ABI,
 	lzo2_is_init,
@@ -161,5 +173,6 @@ compress_ops_t compress_model = {
 	lzo2_fini,
 	lzo2_val_level,
 	lzo2_compress,
-	lzo2_decompress
+	lzo2_decompress,
+	lzo2_get_default_level
 };

--- a/libknet/compress_model.h
+++ b/libknet/compress_model.h
@@ -11,7 +11,8 @@
 
 #include "internals.h"
 
-#define KNET_COMPRESS_MODEL_ABI 1
+#define KNET_COMPRESS_MODEL_ABI            2
+#define KNET_COMPRESS_UNKNOWN_DEFAULT    (-2)
 
 typedef struct {
 	uint8_t abi_ver;
@@ -70,6 +71,11 @@ typedef struct {
 			 const ssize_t buf_in_len,
 			 unsigned char *buf_out,
 			 ssize_t *buf_out_len);
+
+	/*
+	 * Get default compression level
+	 */
+	int (*get_default_level) (void);
 } compress_ops_t;
 
 typedef struct {

--- a/libknet/compress_zlib.c
+++ b/libknet/compress_zlib.c
@@ -15,6 +15,12 @@
 #include "logging.h"
 #include "compress_model.h"
 
+#ifdef Z_DEFAULT_COMPRESSION
+#define KNET_COMPRESS_DEFAULT Z_DEFAULT_COMPRESSION /* zlib default compression level from zlib.h */
+#else
+#define KNET_COMPRESS_DEFAULT KNET_COMPRESS_UNKNOWN_DEFAULT
+#endif
+
 static int zlib_compress(
 	knet_handle_t knet_h,
 	const unsigned char *buf_in,
@@ -106,6 +112,11 @@ static int zlib_decompress(
 	return err;
 }
 
+static int zlib_get_default_level()
+{
+	return KNET_COMPRESS_DEFAULT;
+}
+
 compress_ops_t compress_model = {
 	KNET_COMPRESS_MODEL_ABI,
 	NULL,
@@ -113,5 +124,6 @@ compress_ops_t compress_model = {
 	NULL,
 	NULL,
 	zlib_compress,
-	zlib_decompress
+	zlib_decompress,
+	zlib_get_default_level
 };

--- a/libknet/compress_zstd.c
+++ b/libknet/compress_zstd.c
@@ -17,6 +17,12 @@
 #include "logging.h"
 #include "compress_model.h"
 
+#ifdef ZSTD_CLEVEL_DEFAULT
+#define KNET_COMPRESS_DEFAULT ZSTD_CLEVEL_DEFAULT /* zstd default compression level from zstd.h */
+#else
+#define KNET_COMPRESS_DEFAULT KNET_COMPRESS_UNKNOWN_DEFAULT
+#endif
+
 struct zstd_ctx {
 	ZSTD_CCtx* cctx;
 	ZSTD_DCtx* dctx;
@@ -149,6 +155,11 @@ static int zstd_decompress(
 	return 0;
 }
 
+static int zstd_get_default_level()
+{
+	return KNET_COMPRESS_DEFAULT;
+}
+
 compress_ops_t compress_model = {
 	KNET_COMPRESS_MODEL_ABI,
 	zstd_is_init,
@@ -156,5 +167,6 @@ compress_ops_t compress_model = {
 	zstd_fini,
 	NULL,
 	zstd_compress,
-	zstd_decompress
+	zstd_decompress,
+	zstd_get_default_level
 };

--- a/libknet/tests/api_knet_handle_compress.c
+++ b/libknet/tests/api_knet_handle_compress.c
@@ -81,6 +81,22 @@ static void test(void)
 
 	flush_logs(logfds[0], stdout);
 
+	printf("Test knet_handle_compress with bzip2 (no default) with negative level (-3)\n");
+#ifdef BZIP2_COMPRESS_LEVEL
+        memset(&knet_handle_compress_cfg, 0, sizeof(struct knet_handle_compress_cfg));
+        strncpy(knet_handle_compress_cfg.compress_model, "bzip2", sizeof(knet_handle_compress_cfg.compress_model) - 1);
+        knet_handle_compress_cfg.compress_level = -3;
+
+        if((!knet_handle_compress(knet_h, &knet_handle_compress_cfg)) || (errno != EINVAL)) {
+                printf("knet_handle_compress accepted invalid (-3) compress level and for bzip2, which is no default defined\n");
+                knet_handle_free(knet_h);
+                flush_logs(logfds[0], stdout);
+                close_logpipes(logfds);
+                exit(FAIL);
+        }
+#endif
+	flush_logs(logfds[0], stdout);
+
 	printf("Test knet_handle_compress with zlib compress and not effective compression level (0)\n");
 
 	memset(&knet_handle_compress_cfg, 0, sizeof(struct knet_handle_compress_cfg));

--- a/libknet/tests/api_knet_handle_compress.c
+++ b/libknet/tests/api_knet_handle_compress.c
@@ -81,6 +81,22 @@ static void test(void)
 
 	flush_logs(logfds[0], stdout);
 
+	printf("Test knet_handle_compress with zlib compress and not effective compression level (0)\n");
+
+	memset(&knet_handle_compress_cfg, 0, sizeof(struct knet_handle_compress_cfg));
+	strncpy(knet_handle_compress_cfg.compress_model, "zlib", sizeof(knet_handle_compress_cfg.compress_model) - 1);
+	knet_handle_compress_cfg.compress_level = 0;
+
+	if((knet_handle_compress(knet_h, &knet_handle_compress_cfg)) || (errno == EINVAL)) {
+		printf("knet_handle_compress failed to compress with default compression level\n");
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
 	printf("Test knet_handle_compress with zlib compress and negative level (-2)\n");
 
 	memset(&knet_handle_compress_cfg, 0, sizeof(struct knet_handle_compress_cfg));


### PR DESCRIPTION
If the knet_compression_level not set or out of range, default
compression level specified seems better I think.
btw, thanks fabbione's suggestion: potentially use -1 as compress
module default, because barely any compress module currently accepts -1.
So, this also needs to trim a little bit in corosync.

Signed-off-by: yuan ren <yren@suse.com>