### PR TITLE
coverity scan fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ doxyfile*.stamp
 xml-*/
 doxyxml
 *.3
+cov*

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ dist_doc_DATA		= \
 all-local: $(SPEC)
 
 clean-local:
-	rm -f $(SPEC)
+	rm -rf $(SPEC) cov*
 
 distclean-local:
 	rm -f $(PACKAGE_NAME)-*.tar.* $(PACKAGE_NAME)-*.sha256* tag-*

--- a/build-aux/check.mk
+++ b/build-aux/check.mk
@@ -26,3 +26,21 @@ if HAS_VALGRIND
 else
 	@echo valgrind not available on this platform
 endif
+
+check-covscan:
+if HAS_COVBUILD
+	rm -rf $(abs_top_builddir)/cov*
+	$(MAKE) -C $(abs_top_builddir) clean
+	$(COVBUILD_EXEC) --dir=$(abs_top_builddir)/cov $(MAKE) -C $(abs_top_builddir)
+if HAS_COVANALYZE
+	$(COVANALYZE_EXEC) --dir=$(abs_top_builddir)/cov --wait-for-license $(covoptions)
+if HAS_COVFORMATERRORS
+	$(COVFORMATERRORS_EXEC) --dir=$(abs_top_builddir)/cov --emacs-style > $(abs_top_builddir)/cov.output.txt
+	$(COVFORMATERRORS_EXEC) --dir=$(abs_top_builddir)/cov --html-output $(abs_top_builddir)/cov.html
+endif
+else
+	@echo directory $(abs_top_builddir)/cov ready to be uploaded to https://scan.coverity.com
+endif
+else
+	@echo cov-build not available on this platform
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,15 @@ PKG_PROG_PKG_CONFIG
 AC_CHECK_PROGS([VALGRIND_EXEC], [valgrind])
 AM_CONDITIONAL([HAS_VALGRIND], [test x$VALGRIND_EXEC != "x"])
 
+AC_CHECK_PROGS([COVBUILD_EXEC], [cov-build])
+AM_CONDITIONAL([HAS_COVBUILD], [test x$COVBUILD_EXEC != "x"])
+
+AC_CHECK_PROGS([COVANALYZE_EXEC], [cov-analyze])
+AM_CONDITIONAL([HAS_COVANALYZE], [test x$COVANALYZE_EXEC != "x"])
+
+AC_CHECK_PROGS([COVFORMATERRORS_EXEC], [cov-format-errors])
+AM_CONDITIONAL([HAS_COVFORMATERRORS], [test x$COVFORMATERRORS_EXEC != "x"])
+
 # KNET_OPTION_DEFINES(stem,type,detection code)
 # stem: enters name of option, Automake conditional and preprocessor define
 # type: compress or crypto, determines where the default comes from

--- a/libknet/common.c
+++ b/libknet/common.c
@@ -67,10 +67,13 @@ static void *open_lib(knet_handle_t knet_h, const char *libname, int extra_flags
 	dlerror();
 
 	ret = dlopen(libname, RTLD_NOW | RTLD_GLOBAL | extra_flags);
-	error = dlerror();
-	if (error != NULL) {
-		log_err(knet_h, KNET_SUB_COMMON, "unable to dlopen %s: %s",
-			libname, error);
+	if (!ret) {
+		error = dlerror();
+		if (error) {
+			log_err(knet_h, KNET_SUB_COMMON, "unable to dlopen %s: %s", libname, error);
+		} else {
+			log_err(knet_h, KNET_SUB_COMMON, "unable to dlopen %s: unknown error", libname);
+		}
 		errno = EAGAIN;
 		return NULL;
 	}

--- a/libknet/common.c
+++ b/libknet/common.c
@@ -108,6 +108,7 @@ static void *open_lib(knet_handle_t knet_h, const char *libname, int extra_flags
 				log_debug(knet_h, KNET_SUB_COMMON, "Unable to readlink %s: %s", path, strerror(errno));
 				goto out;
 			}
+			link[sizeof(link) - 1] = 0;
 			/*
 			 * symlink is relative to the directory
 			 */

--- a/libknet/compress.c
+++ b/libknet/compress.c
@@ -32,7 +32,7 @@
  * Always add new items before the last NULL.
  */
 
-static compress_model_t compress_modules_cmds[] = {
+static compress_model_t compress_modules_cmds[KNET_MAX_COMPRESS_METHODS + 1] = {
 	{ "none" , 0, 0, 0, NULL },
 	{ "zlib" , 1, WITH_COMPRESS_ZLIB , 0, NULL },
 	{ "lz4"  , 2, WITH_COMPRESS_LZ4  , 0, NULL },
@@ -41,7 +41,7 @@ static compress_model_t compress_modules_cmds[] = {
 	{ "lzma" , 5, WITH_COMPRESS_LZMA , 0, NULL },
 	{ "bzip2", 6, WITH_COMPRESS_BZIP2, 0, NULL },
 	{ "zstd" , 7, WITH_COMPRESS_ZSTD, 0, NULL },
-	{ NULL, 255, 0, 0, NULL }
+	{ NULL, KNET_MAX_COMPRESS_METHODS, 0, 0, NULL }
 };
 
 static int max_model = 0;
@@ -387,8 +387,8 @@ void compress_fini(
 		return;
 	}
 
-	while (compress_modules_cmds[idx].model_name != NULL) {
-		if ((idx < KNET_MAX_COMPRESS_METHODS) && /* check idx first so we don't read bad data */
+	while (idx < KNET_MAX_COMPRESS_METHODS) {
+		if ((compress_modules_cmds[idx].model_name != NULL) &&
 		    (compress_modules_cmds[idx].built_in == 1) &&
 		    (compress_modules_cmds[idx].loaded == 1) &&
 		    (compress_modules_cmds[idx].model_id > 0) &&

--- a/libknet/compress_zstd.c
+++ b/libknet/compress_zstd.c
@@ -72,6 +72,8 @@ static int zstd_init(
 		}
 		memset(zstd_ctx, 0, sizeof(struct zstd_ctx));
 
+		knet_h->compress_int_data[method_idx] = zstd_ctx;
+
 		zstd_ctx->cctx = ZSTD_createCCtx();
 		if (!zstd_ctx->cctx) {
 			log_err(knet_h, KNET_SUB_ZSTDCOMP, "Unable to create compression context");
@@ -85,8 +87,6 @@ static int zstd_init(
 			err = -1;
 			goto out_err;
 		}
-
-		knet_h->compress_int_data[method_idx] = zstd_ctx;
 	}
 
 out_err:

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -234,14 +234,14 @@ static int _init_buffers(knet_handle_t knet_h)
 	}
 	memset(knet_h->pingbuf, 0, KNET_HEADER_PING_SIZE);
 
-	knet_h->pmtudbuf = malloc(KNET_PMTUD_SIZE_V6);
+	knet_h->pmtudbuf = malloc(KNET_PMTUD_SIZE_V6 + KNET_HEADER_ALL_SIZE);
 	if (!knet_h->pmtudbuf) {
 		savederrno = errno;
 		log_err(knet_h, KNET_SUB_HANDLE, "Unable to allocate memory for pmtud buffer: %s",
 			strerror(savederrno));
 		goto exit_fail;
 	}
-	memset(knet_h->pmtudbuf, 0, KNET_PMTUD_SIZE_V6);
+	memset(knet_h->pmtudbuf, 0, KNET_PMTUD_SIZE_V6 + KNET_HEADER_ALL_SIZE);
 
 	for (i = 0; i < PCKT_FRAG_MAX; i++) {
 		bufsize = ceil((float)KNET_MAX_PACKET_SIZE / (i + 1)) + KNET_HEADER_ALL_SIZE + KNET_DATABUFSIZE_CRYPT_PAD;

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -90,8 +90,8 @@ struct knet_host_defrag_buf {
 	uint8_t frag_recv;		/* how many frags did we receive */
 	uint8_t frag_map[PCKT_FRAG_MAX];/* bitmap of what we received? */
 	uint8_t	last_first;		/* special case if we receive the last fragment first */
-	uint16_t frag_size;		/* normal frag size (not the last one) */
-	uint16_t last_frag_size;	/* the last fragment might not be aligned with MTU size */
+	ssize_t frag_size;		/* normal frag size (not the last one) */
+	ssize_t last_frag_size;		/* the last fragment might not be aligned with MTU size */
 	struct timespec last_update;	/* keep time of the last pckt */
 };
 

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -33,7 +33,9 @@
 #define PCKT_FRAG_MAX UINT8_MAX
 #define PCKT_RX_BUFS  512
 
-#define KNET_EPOLL_MAX_EVENTS KNET_DATAFD_MAX
+#define KNET_EPOLL_MAX_EVENTS KNET_DATAFD_MAX + 1
+
+#define KNET_INTERNAL_DATA_CHANNEL KNET_DATAFD_MAX
 
 typedef void *knet_transport_link_t; /* per link transport handle */
 typedef void *knet_transport_t;      /* per knet_h transport handle */
@@ -151,7 +153,7 @@ struct knet_handle_stats_extra {
 struct knet_handle {
 	knet_node_id_t host_id;
 	unsigned int enabled:1;
-	struct knet_sock sockfd[KNET_DATAFD_MAX];
+	struct knet_sock sockfd[KNET_DATAFD_MAX + 1];
 	int logfd;
 	uint8_t log_levels[KNET_MAX_SUBSYSTEMS];
 	int hostsockfd[2];

--- a/libknet/links_acl_ip.c
+++ b/libknet/links_acl_ip.c
@@ -279,10 +279,15 @@ int ipcheck_addip(void *fd_tracker_match_entry_head, int index,
 			/*
 			 * find the end of the list or stop at "index"
 			 */
-			while ((match_entry->next) || (i < index)) {
+
+			while (match_entry->next) {
 				match_entry = match_entry->next;
+				if (i == index) {
+					break;
+				}
 				i++;
 			}
+
 			/*
 			 * insert if there are more entries in the list
 			 */

--- a/libknet/logging.c
+++ b/libknet/logging.c
@@ -20,7 +20,7 @@
 #include "logging.h"
 #include "threads_common.h"
 
-static struct pretty_names subsystem_names[] =
+static struct pretty_names subsystem_names[KNET_MAX_SUBSYSTEMS] =
 {
 	{ "common", KNET_SUB_COMMON },
 	{ "handle", KNET_SUB_HANDLE },
@@ -99,7 +99,7 @@ static int is_valid_subsystem(uint8_t subsystem)
 	return -1;
 }
 
-static struct pretty_names loglevel_names[] =
+static struct pretty_names loglevel_names[KNET_LOG_DEBUG + 1] =
 {
 	{ "ERROR", KNET_LOG_ERR },
 	{ "WARNING", KNET_LOG_WARN },

--- a/libknet/tests/knet_bench.c
+++ b/libknet/tests/knet_bench.c
@@ -276,22 +276,24 @@ static void setup_knet(int argc, char *argv[])
 					printf("Error: -p can only be specified once\n");
 					exit(FAIL);
 				}
-				policystr = optarg;
-				if (!strcmp(policystr, "active")) {
-					policy = KNET_LINK_POLICY_ACTIVE;
-					policyfound = 1;
-				}
-				/*
-				 * we can't use rr because clangs can't compile
-				 * an array of 3 strings, one of which is 2 bytes long
-				 */
-				if (!strcmp(policystr, "round-robin")) {
-					policy = KNET_LINK_POLICY_RR;
-					policyfound = 1;
-				}
-				if (!strcmp(policystr, "passive")) {
-					policy = KNET_LINK_POLICY_PASSIVE;
-					policyfound = 1;
+				if (optarg) {
+					policystr = optarg;
+					if (!strcmp(policystr, "active")) {
+						policy = KNET_LINK_POLICY_ACTIVE;
+						policyfound = 1;
+					}
+					/*
+					 * we can't use rr because clangs can't compile
+					 * an array of 3 strings, one of which is 2 bytes long
+					 */
+					if (!strcmp(policystr, "round-robin")) {
+						policy = KNET_LINK_POLICY_RR;
+						policyfound = 1;
+					}
+					if (!strcmp(policystr, "passive")) {
+						policy = KNET_LINK_POLICY_PASSIVE;
+						policyfound = 1;
+					}
 				}
 				if (!policyfound) {
 					printf("Error: invalid policy %s specified. -p accepts active|passive|rr\n", policystr);
@@ -303,14 +305,16 @@ static void setup_knet(int argc, char *argv[])
 					printf("Error: -P can only be specified once\n");
 					exit(FAIL);
 				}
-				protostr = optarg;
-				if (!strcmp(protostr, "UDP")) {
-					protocol = KNET_TRANSPORT_UDP;
-					protofound = 1;
-				}
-				if (!strcmp(protostr, "SCTP")) {
-					protocol = KNET_TRANSPORT_SCTP;
-					protofound = 1;
+				if (optarg) {
+					protostr = optarg;
+					if (!strcmp(protostr, "UDP")) {
+						protocol = KNET_TRANSPORT_UDP;
+						protofound = 1;
+					}
+					if (!strcmp(protostr, "SCTP")) {
+						protocol = KNET_TRANSPORT_SCTP;
+						protofound = 1;
+					}
 				}
 				if (!protofound) {
 					printf("Error: invalid protocol %s specified. -P accepts udp|sctp\n", policystr);
@@ -379,17 +383,22 @@ static void setup_knet(int argc, char *argv[])
 				}
 				break;
 			case 'T':
-				if (!strcmp("ping", optarg)) {
-					test_type = TEST_PING;
-				}
-				if (!strcmp("ping_data", optarg)) {
-					test_type = TEST_PING_AND_DATA;
-				}
-				if (!strcmp("perf-by-size", optarg)) {
-					test_type = TEST_PERF_BY_SIZE;
-				}
-				if (!strcmp("perf-by-time", optarg)) {
-					test_type = TEST_PERF_BY_TIME;
+				if (optarg) {
+					if (!strcmp("ping", optarg)) {
+						test_type = TEST_PING;
+					}
+					if (!strcmp("ping_data", optarg)) {
+						test_type = TEST_PING_AND_DATA;
+					}
+					if (!strcmp("perf-by-size", optarg)) {
+						test_type = TEST_PERF_BY_SIZE;
+					}
+					if (!strcmp("perf-by-time", optarg)) {
+						test_type = TEST_PERF_BY_TIME;
+					}
+				} else {
+					printf("Error: -T requires an option\n");
+					exit(FAIL);
 				}
 				break;
 			case 'S':
@@ -956,15 +965,14 @@ static void display_stats(int level)
 	struct knet_link_stats total_link_stats;
 	knet_node_id_t host_list[KNET_MAX_HOST];
 	uint8_t link_list[KNET_MAX_LINK];
-	int res;
 	unsigned int i,j;
 	size_t num_hosts, num_links;
 
-	res = knet_handle_get_stats(knet_h, &handle_stats, sizeof(handle_stats));
-	if (res) {
+	if (knet_handle_get_stats(knet_h, &handle_stats, sizeof(handle_stats)) < 0) {
 		perror("[info]: failed to get knet handle stats");
 		return;
 	}
+
 	if (compresscfg || cryptocfg) {
 		printf("\n");
 		printf("[stat]: handle stats\n");
@@ -1007,8 +1015,7 @@ static void display_stats(int level)
 
 	memset(&total_link_stats, 0, sizeof(struct knet_link_stats));
 
-	res = knet_host_get_host_list(knet_h, host_list, &num_hosts);
-	if (res) {
+	if (knet_host_get_host_list(knet_h, host_list, &num_hosts) < 0) {
 		perror("[info]: cannot get host list for stats");
 		return;
 	}
@@ -1017,18 +1024,16 @@ static void display_stats(int level)
 	qsort(host_list, num_hosts, sizeof(uint16_t), node_compare);
 
 	for (j=0; j<num_hosts; j++) {
-		res = knet_link_get_link_list(knet_h, host_list[j], link_list, &num_links);
-		if (res) {
+		if (knet_link_get_link_list(knet_h, host_list[j], link_list, &num_links) < 0) {
 			perror("[info]: cannot get link list for stats");
 			return;
 		}
 
 		for (i=0; i < num_links; i++) {
-			res = knet_link_get_status(knet_h,
-						   host_list[j],
-						   link_list[i],
-						   &link_status,
-						   sizeof(link_status));
+			if (knet_link_get_status(knet_h, host_list[j], link_list[i], &link_status, sizeof(link_status)) < 0) {
+				perror("[info]: cannot get link status");
+				return;
+			}
 
 			total_link_stats.tx_data_packets += link_status.stats.tx_data_packets;
 			total_link_stats.rx_data_packets += link_status.stats.rx_data_packets;

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -294,7 +294,11 @@ retry:
 			return -1;
 		}
 
-		if (shutdown_in_progress(knet_h)) {
+		/*
+		 * we cannot use shutdown_in_progress in here because
+		 * we already hold the read lock
+		 */
+		if (knet_h->fini_in_progress) {
 			pthread_mutex_unlock(&knet_h->pmtud_mutex);
 			log_debug(knet_h, KNET_SUB_PMTUD, "PMTUD aborted. shutdown in progress");
 			return -1;

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -814,11 +814,14 @@ static void _handle_recv_from_links(knet_handle_t knet_h, int sockfd, struct kne
 
 						memset(src_ipaddr, 0, KNET_MAX_HOST_LEN);
 						memset(src_port, 0, KNET_MAX_PORT_LEN);
-						knet_addrtostr(msg[i].msg_hdr.msg_name, sockaddr_len(msg[i].msg_hdr.msg_name),
-							       src_ipaddr, KNET_MAX_HOST_LEN,
-							       src_port, KNET_MAX_PORT_LEN);
+						if (knet_addrtostr(msg[i].msg_hdr.msg_name, sockaddr_len(msg[i].msg_hdr.msg_name),
+								   src_ipaddr, KNET_MAX_HOST_LEN,
+								   src_port, KNET_MAX_PORT_LEN) < 0) {
 
-						log_debug(knet_h, KNET_SUB_RX, "Packet rejected from %s/%s", src_ipaddr, src_port);
+							log_debug(knet_h, KNET_SUB_RX, "Packet rejected: unable to resolve host/port");
+						} else {
+							log_debug(knet_h, KNET_SUB_RX, "Packet rejected from %s/%s", src_ipaddr, src_port);
+						}
 						/*
 						 * continue processing the other packets
 						 */

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -235,7 +235,6 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 						local_link->status.stats.tx_data_retries++;
 						buf += err;
 						buflen -= err;
-						usleep(knet_h->threads_timer_res / 16);
 						goto local_retry;
 					}
 					if (err == buflen) {

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -648,19 +648,25 @@ static void _handle_send_to_links(knet_handle_t knet_h, struct msghdr *msg, int 
 		docallback = 1;
 		memset(&ev, 0, sizeof(struct epoll_event));
 
-		if (epoll_ctl(knet_h->send_to_links_epollfd,
-			      EPOLL_CTL_DEL, knet_h->sockfd[channel].sockfd[knet_h->sockfd[channel].is_created], &ev)) {
-			log_err(knet_h, KNET_SUB_TX, "Unable to del datafd %d from linkfd epoll pool: %s",
-				knet_h->sockfd[channel].sockfd[0], strerror(savederrno));
-		} else {
-			knet_h->sockfd[channel].has_error = 1;
+		if (channel != KNET_INTERNAL_DATA_CHANNEL) {
+			if (epoll_ctl(knet_h->send_to_links_epollfd,
+				      EPOLL_CTL_DEL, knet_h->sockfd[channel].sockfd[knet_h->sockfd[channel].is_created], &ev)) {
+				log_err(knet_h, KNET_SUB_TX, "Unable to del datafd %d from linkfd epoll pool: %s",
+					knet_h->sockfd[channel].sockfd[0], strerror(savederrno));
+			} else {
+				knet_h->sockfd[channel].has_error = 1;
+			}
 		}
+		/*
+		 * TODO: add error handling for KNET_INTERNAL_DATA_CHANNEL
+		 *       once we add support for internal knet communication
+		 */
 	} else {
 		knet_h->recv_from_sock_buf->kh_type = type;
 		_parse_recv_from_sock(knet_h, inlen, channel, 0);
 	}
 
-	if (docallback) {
+	if ((docallback) && (channel != KNET_INTERNAL_DATA_CHANNEL)) {
 		knet_h->sock_notify_fn(knet_h->sock_notify_fn_private_data,
 				       knet_h->sockfd[channel].sockfd[0],
 				       channel,
@@ -754,7 +760,7 @@ void *_handle_send_to_links_thread(void *data)
 		for (i = 0; i < nev; i++) {
 			if (events[i].data.fd == knet_h->hostsockfd[0]) {
 				type = KNET_HEADER_TYPE_HOST_INFO;
-				channel = -1;
+				channel = KNET_INTERNAL_DATA_CHANNEL;
 			} else {
 				type = KNET_HEADER_TYPE_DATA;
 				for (channel = 0; channel < KNET_DATAFD_MAX; channel++) {

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -1037,8 +1037,8 @@ exit_error:
 		if ((info) && (info->on_listener_epoll)) {
 			epoll_ctl(handle_info->listen_epollfd, EPOLL_CTL_DEL, listen_sock, &ev);
 		}
-		check_rmall(knet_h, listen_sock, KNET_TRANSPORT_SCTP);
 		if (listen_sock >= 0) {
+			check_rmall(knet_h, listen_sock, KNET_TRANSPORT_SCTP);
 			close(listen_sock);
 		}
 		if (info) {

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -811,12 +811,14 @@ static void _handle_incoming_sctp(knet_handle_t knet_h, int listen_sock)
 
 exit_error:
 	if (err) {
-		if ((i >= 0) || (i < MAX_ACCEPTED_SOCKS)) {
+		if ((i >= 0) && (i < MAX_ACCEPTED_SOCKS)) {
 			info->accepted_socks[i] = -1;
 		}
 		_set_fd_tracker(knet_h, new_fd, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, NULL);
 		free(accept_info);
-		close(new_fd);
+		if (new_fd >= 0) {
+			close(new_fd);
+		}
 	}
 	errno = savederrno;
 	return;
@@ -1205,7 +1207,7 @@ int sctp_transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_li
 exit_error:
 	if (err) {
 		if (info) {
-			if (info->connect_sock) {
+			if (info->connect_sock >= 0) {
 				close(info->connect_sock);
 			}
 			if (info->listener) {

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -611,6 +611,13 @@ static void _handle_connected_sctp_errors(knet_handle_t knet_h)
 		return;
 	}
 
+	/*
+	 * revalidate sockfd
+	 */
+	if ((sockfd < 0) || (sockfd >= KNET_MAX_FDS)) {
+		return;
+	}
+
 	log_debug(knet_h, KNET_SUB_TRANSP_SCTP, "Processing connected error on socket: %d", sockfd);
 
 	info = knet_h->knet_transport_fd_tracker[sockfd].data;
@@ -836,6 +843,13 @@ static void _handle_listen_sctp_errors(knet_handle_t knet_h)
 
 	if (_is_valid_fd(knet_h, sockfd) < 1) {
 		log_debug(knet_h, KNET_SUB_TRANSP_SCTP, "Received stray notification for listen socket fd error");
+		return;
+	}
+
+	/*
+	 * revalidate sockfd
+	 */
+	if ((sockfd < 0) || (sockfd >= KNET_MAX_FDS)) {
 		return;
 	}
 

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -1034,7 +1034,7 @@ static sctp_listen_link_info_t *sctp_link_listener_start(knet_handle_t knet_h, s
 
 exit_error:
 	if (err) {
-		if (info->on_listener_epoll) {
+		if ((info) && (info->on_listener_epoll)) {
 			epoll_ctl(handle_info->listen_epollfd, EPOLL_CTL_DEL, listen_sock, &ev);
 		}
 		check_rmall(knet_h, listen_sock, KNET_TRANSPORT_SCTP);

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include "compat.h"
 #include "host.h"
@@ -274,6 +275,32 @@ exit_error:
 	return err;
 }
 
+static void _lock_sleep_relock(knet_handle_t knet_h)
+{
+	int i = 0;
+
+	/* Don't hold onto the lock while sleeping */
+	pthread_rwlock_unlock(&knet_h->global_rwlock);
+
+	while (i < 5) {
+		usleep(knet_h->threads_timer_res / 16);
+		if (!pthread_rwlock_rdlock(&knet_h->global_rwlock)) {
+			/*
+			 * lock acquired, we can go out
+			 */
+			return;
+		} else {
+			log_debug(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to get read lock!");
+			i++;
+		}
+	}
+	/*
+	 * time to crash! if we cannot re-acquire the lock
+	 * there is no easy way out of this one
+	 */
+	assert(0);
+}
+
 int sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
 {
 	sctp_connect_link_info_t *connect_info = knet_h->knet_transport_fd_tracker[sockfd].data;
@@ -300,10 +327,7 @@ int sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err,
 #ifdef DEBUG
 			log_debug(knet_h, KNET_SUB_TRANSP_SCTP, "Sock: %d is overloaded. Slowing TX down", sockfd);
 #endif
-			/* Don't hold onto the lock while sleeping */
-			pthread_rwlock_unlock(&knet_h->global_rwlock);
-			usleep(knet_h->threads_timer_res / 16);
-			pthread_rwlock_rdlock(&knet_h->global_rwlock);
+			_lock_sleep_relock(knet_h);
 			return 1;
 		}
 		return -1;
@@ -406,10 +430,7 @@ int sctp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err,
 	 * Under RX pressure we need to give time to IPC to pick up the message
 	 */
 
-	/* Don't hold onto the lock while sleeping */
-	pthread_rwlock_unlock(&knet_h->global_rwlock);
-	usleep(knet_h->threads_timer_res / 2);
-	pthread_rwlock_rdlock(&knet_h->global_rwlock);
+	_lock_sleep_relock(knet_h);
 	return 0;
 }
 

--- a/libnozzle/internals.h
+++ b/libnozzle/internals.h
@@ -34,7 +34,7 @@ struct nozzle_lib_config {
 #define UPDOWN_PATH_MAX    PATH_MAX - 11 - 1 - IFNAMSIZ
 
 struct nozzle_iface {
-	char name[IFNAMSIZ];		/* interface name */
+	char name[IFNAMSIZ - 1];	/* interface name */
 	int fd;				/* interface fd */
 	int up;				/* interface status 0 is down, 1 is up */
 	/*

--- a/libnozzle/libnozzle.c
+++ b/libnozzle/libnozzle.c
@@ -508,7 +508,7 @@ nozzle_t nozzle_open(char *devname, size_t devname_size, const char *updownpath)
 		goto out_error;
 	}
 	strncpy(devname, curnozzle, IFNAMSIZ);
-	strncpy(nozzle->name, curnozzle, IFNAMSIZ);
+	memmove(nozzle->name, curnozzle, IFNAMSIZ - 1);
 #endif
 
 #ifdef KNET_LINUX
@@ -532,7 +532,7 @@ nozzle_t nozzle_open(char *devname, size_t devname_size, const char *updownpath)
 	}
 
 	strncpy(devname, ifname, IFNAMSIZ);
-	strncpy(nozzle->name, ifname, IFNAMSIZ);
+	memmove(nozzle->name, ifname, IFNAMSIZ - 1);
 #endif
 
 	nozzle->default_mtu = get_iface_mtu(nozzle);

--- a/libnozzle/libnozzle.c
+++ b/libnozzle/libnozzle.c
@@ -252,7 +252,8 @@ static int _set_ip(nozzle_t nozzle,
 	addr = rtnl_addr_alloc();
 	if (!addr) {
 		errno = ENOMEM;
-		return -1;
+		err = -1;
+		goto out;
 	}
 
 	if (rtnl_link_alloc_cache(lib_cfg.nlsock, AF_UNSPEC, &cache) < 0) {

--- a/libnozzle/libnozzle.c
+++ b/libnozzle/libnozzle.c
@@ -104,7 +104,7 @@ static void destroy_iface(nozzle_t nozzle)
 	if (!nozzle)
 		return;
 
-	if (nozzle->fd)
+	if (nozzle->fd >= 0)
 		close(nozzle->fd);
 
 #ifdef KNET_BSD

--- a/libnozzle/tests/api_nozzle_get_name_by_handle.c
+++ b/libnozzle/tests/api_nozzle_get_name_by_handle.c
@@ -33,8 +33,12 @@ static int test(void)
 	}
 
 	device_name_tmp = nozzle_get_name_by_handle(nozzle);
-	if ((!device_name_tmp) && (errno != ENOENT)) {
-		printf("Unable to get name by handle\n");
+	if (!device_name_tmp) {
+		if (errno != ENOENT) {
+			printf("Unable to get name by handle\n");
+		} else {
+			printf("received incorrect errno!\n");
+		}
 		err = -1;
 		goto out_clean;
 	}

--- a/libnozzle/tests/api_nozzle_set_mac.c
+++ b/libnozzle/tests/api_nozzle_set_mac.c
@@ -34,7 +34,7 @@ static int test(void)
 	size_t size = IFNAMSIZ;
 	int err=0;
 	nozzle_t nozzle;
-	char *original_mac = NULL, *current_mac = NULL, *temp_mac = NULL, *err_mac = NULL;
+	char *original_mac = NULL, *current_mac = NULL, *temp_mac = NULL;
 	struct ether_addr *orig_mac, *cur_mac, *tmp_mac;
 
 	printf("Testing set MAC\n");
@@ -96,8 +96,10 @@ static int test(void)
 		goto out_clean;
 	}
 
-	if (current_mac)
+	if (current_mac) {
 		free(current_mac);
+		current_mac = NULL;
+	}
 
 	if (nozzle_get_mac(nozzle, &current_mac) < 0) {
 		printf("Unable to get current MAC address.\n");
@@ -124,19 +126,13 @@ static int test(void)
 
 	printf("Pass NULL to set_mac (pass2)\n");
 	errno = 0;
-	if ((nozzle_set_mac(NULL, err_mac) >= 0) || (errno != EINVAL)) {
+	if ((nozzle_set_mac(NULL, current_mac) >= 0) || (errno != EINVAL)) {
 		printf("Something is wrong in nozzle_set_mac sanity checks\n");
 		err = -1;
 		goto out_clean;
 	}
 
 out_clean:
-	if (err_mac) {
-		printf("Something managed to set err_mac!\n");
-		err = -1;
-		free(err_mac);
-	}
-
 	if (current_mac)
 		free(current_mac);
 	if (temp_mac)


### PR DESCRIPTION
this PR addresses all the major issues reported by coverity scan on the runtime code.

There are still a bunch of issues left in the test suite and doxyxml.c that is executed only during build time to generate man pages.

coverity scan will report an error in libknet/thread_tx.c related to the channel variable. The error is correct, there is some code that will need to be fixed, but at the moment, the if () branch that sets channel = -1 is dead and nothing in knet triggers that code (it was left in preparation for knet 2.0).

This PR fixes https://github.com/kronosnet/kronosnet/issues/237