### PR TITLE
[PMTUd] rework the whole math to calculate MTU

### DIFF
--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -36,6 +36,7 @@ sources			= \
 			  links_acl_loopback.c \
 			  logging.c \
 			  netutils.c \
+			  onwire.c \
 			  threads_common.c \
 			  threads_dsthandler.c \
 			  threads_heartbeat.c \

--- a/libknet/crypto.c
+++ b/libknet/crypto.c
@@ -154,12 +154,14 @@ int crypto_init(
 out:
 	if (!err) {
 		knet_h->crypto_instance = new;
-		knet_h->sec_header_size = new->sec_header_size;
 		knet_h->sec_block_size = new->sec_block_size;
 		knet_h->sec_hash_size = new->sec_hash_size;
 		knet_h->sec_salt_size = new->sec_salt_size;
 
-		log_debug(knet_h, KNET_SUB_CRYPTO, "security network overhead: %zu", knet_h->sec_header_size);
+		log_debug(knet_h, KNET_SUB_CRYPTO, "Hash size: %zu salt size: %zu block size: %zu",
+			  knet_h->sec_hash_size,
+			  knet_h->sec_salt_size,
+			  knet_h->sec_block_size);
 
 		if (current) {
 			if (crypto_modules_cmds[current->model].ops->fini != NULL) {
@@ -195,7 +197,6 @@ void crypto_fini(
 			crypto_modules_cmds[knet_h->crypto_instance->model].ops->fini(knet_h, knet_h->crypto_instance);
 		}
 		free(knet_h->crypto_instance);
-		knet_h->sec_header_size = 0;
 		knet_h->sec_block_size = 0;
 		knet_h->sec_hash_size = 0;
 		knet_h->sec_salt_size = 0;

--- a/libknet/crypto_model.h
+++ b/libknet/crypto_model.h
@@ -14,13 +14,12 @@
 struct crypto_instance {
 	int	model;
 	void	*model_instance;
-	size_t	sec_header_size;
 	size_t	sec_block_size;
 	size_t	sec_hash_size;
 	size_t	sec_salt_size;
 };
 
-#define KNET_CRYPTO_MODEL_ABI 2
+#define KNET_CRYPTO_MODEL_ABI 3
 
 /*
  * see compress_model.h for explanation of the various lib related functions

--- a/libknet/crypto_nss.c
+++ b/libknet/crypto_nss.c
@@ -801,10 +801,7 @@ static int nsscrypto_init(
 		goto out_err;
 	}
 
-	crypto_instance->sec_header_size = 0;
-
 	if (nsscrypto_instance->crypto_hash_type > 0) {
-		crypto_instance->sec_header_size += nsshash_len[nsscrypto_instance->crypto_hash_type];
 		crypto_instance->sec_hash_size = nsshash_len[nsscrypto_instance->crypto_hash_type];
 	}
 
@@ -821,8 +818,6 @@ static int nsscrypto_init(
 			}
 		}
 
-		crypto_instance->sec_header_size += (block_size * 2);
-		crypto_instance->sec_header_size += SALT_SIZE;
 		crypto_instance->sec_salt_size = SALT_SIZE;
 		crypto_instance->sec_block_size = block_size;
 	}

--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -566,11 +566,8 @@ static int opensslcrypto_init(
 	memmove(opensslcrypto_instance->private_key, knet_handle_crypto_cfg->private_key, knet_handle_crypto_cfg->private_key_len);
 	opensslcrypto_instance->private_key_len = knet_handle_crypto_cfg->private_key_len;
 
-	crypto_instance->sec_header_size = 0;
-
 	if (opensslcrypto_instance->crypto_hash_type) {
 		crypto_instance->sec_hash_size = EVP_MD_size(opensslcrypto_instance->crypto_hash_type);
-		crypto_instance->sec_header_size += crypto_instance->sec_hash_size;
 	}
 
 	if (opensslcrypto_instance->crypto_cipher_type) {
@@ -578,8 +575,6 @@ static int opensslcrypto_init(
 
 		block_size = EVP_CIPHER_block_size(opensslcrypto_instance->crypto_cipher_type);
 
-		crypto_instance->sec_header_size += (block_size * 2);
-		crypto_instance->sec_header_size += SALT_SIZE;
 		crypto_instance->sec_salt_size = SALT_SIZE;
 		crypto_instance->sec_block_size = block_size;
 	}

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -73,7 +73,9 @@ struct knet_link {
 	uint8_t received_pong;
 	struct timespec ping_last;
 	/* used by PMTUD thread as temp per-link variables and should always contain the onwire_len value! */
-	uint32_t proto_overhead;
+	uint32_t proto_overhead;		/* IP + UDP/SCTP overhead. NOT to be confused
+						   with stats.proto_overhead that includes also knet headers
+						   and crypto headers */
 	struct timespec pmtud_last;
 	uint32_t last_ping_size;
 	uint32_t last_good_mtu;
@@ -201,7 +203,6 @@ struct knet_handle {
 	int pmtud_forcerun;
 	int pmtud_abort;
 	struct crypto_instance *crypto_instance;
-	size_t sec_header_size;
 	size_t sec_block_size;
 	size_t sec_hash_size;
 	size_t sec_salt_size;

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -166,6 +166,7 @@ struct knet_handle {
 	int dst_link_handler_epollfd;
 	uint8_t use_access_lists; /* set to 0 for disable, 1 for enable */
 	unsigned int pmtud_interval;
+	unsigned int manual_mtu;
 	unsigned int data_mtu;	/* contains the max data size that we can send onwire
 				 * without frags */
 	struct knet_host *host_head;

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -82,6 +82,7 @@ struct knet_link {
 	uint32_t last_bad_mtu;
 	uint32_t last_sent_mtu;
 	uint32_t last_recv_mtu;
+	uint32_t pmtud_crypto_timeout_multiplier;/* used by PMTUd to adjust timeouts on high loads */
 	uint8_t has_valid_mtu;
 };
 

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -664,6 +664,32 @@ int knet_handle_enable_pmtud_notify(knet_handle_t knet_h,
 						unsigned int data_mtu));
 
 /**
+ * knet_handle_pmtud_set
+ *
+ * @brief Set the current interface MTU
+ *
+ * knet_h    - pointer to knet_handle_t
+ *
+ * iface_mtu - current interface MTU, value 0 to 65535. 0 will
+ *             re-enable automatic MTU discovery.
+ *             In a setup with multiple interfaces, please specify
+ *             the lowest MTU between the selected intefaces.
+ *             knet will automatically adjust this value for
+ *             all headers overhead and set the correct data_mtu.
+ *             data_mtu can be retrivied with knet_handle_pmtud_get(3)
+ *             or applications will receive a pmtud_nofity event
+ *             if enabled via knet_handle_enable_pmtud_notify(3).
+ *
+ * @return
+ * knet_handle_pmtud_set returns
+ * 0 on success
+ * -1 on error and errno is set.
+ */
+
+int knet_handle_pmtud_set(knet_handle_t knet_h,
+			  unsigned int iface_mtu);
+
+/**
  * knet_handle_pmtud_get
  *
  * @brief Get the current data MTU

--- a/libknet/links.c
+++ b/libknet/links.c
@@ -238,6 +238,7 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 		}
 	}
 
+	link->pmtud_crypto_timeout_multiplier = KNET_LINK_PMTUD_CRYPTO_TIMEOUT_MULTIPLIER_MIN;
 	link->pong_count = KNET_LINK_DEFAULT_PONG_COUNT;
 	link->has_valid_mtu = 0;
 	link->ping_interval = KNET_LINK_DEFAULT_PING_INTERVAL * 1000; /* microseconds */

--- a/libknet/links.c
+++ b/libknet/links.c
@@ -284,7 +284,32 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 		host->status.reachable = 1;
 		link->status.mtu = KNET_PMTUD_SIZE_V6;
 	} else {
-		link->status.mtu =  KNET_PMTUD_MIN_MTU_V4 - KNET_HEADER_ALL_SIZE - knet_h->sec_header_size;
+		/*
+		 * calculate the minimum MTU that is safe to use,
+		 * based on RFCs and that each network device should
+		 * be able to support without any troubles
+		 */
+		if (link->dynamic == KNET_LINK_STATIC) {
+			/*
+			 * with static link we can be more precise than using
+			 * the generic calc_min_mtu()
+			 */
+			switch (link->dst_addr.ss_family) {
+				case AF_INET6:
+					link->status.mtu =  calc_max_data_outlen(knet_h, KNET_PMTUD_MIN_MTU_V6 - (KNET_PMTUD_OVERHEAD_V6 + link->proto_overhead));
+					break;
+				case AF_INET:
+					link->status.mtu =  calc_max_data_outlen(knet_h, KNET_PMTUD_MIN_MTU_V4 - (KNET_PMTUD_OVERHEAD_V4 + link->proto_overhead));
+					break;
+			}
+		} else {
+			/*
+			 * for dynamic links we start with the minimum MTU
+			 * possible and PMTUd will kick in immediately
+			 * after connection status is 1
+			 */
+			link->status.mtu =  calc_min_mtu(knet_h);
+		}
 		link->has_valid_mtu = 1;
 	}
 

--- a/libknet/links.h
+++ b/libknet/links.h
@@ -30,6 +30,16 @@
  */
 #define KNET_LINK_PONG_TIMEOUT_LAT_MUL	2
 
+/*
+ * under heavy load with crypto enabled, it takes much
+ * longer time to receive a response from the other node.
+ *
+ * 128 is somewhat arbitrary number but we want to set a limit
+ * and report failures after that.
+ */
+#define KNET_LINK_PMTUD_CRYPTO_TIMEOUT_MULTIPLIER_MIN	  2
+#define KNET_LINK_PMTUD_CRYPTO_TIMEOUT_MULTIPLIER_MAX	128
+
 int _link_updown(knet_handle_t knet_h, knet_node_id_t node_id, uint8_t link_id,
 		 unsigned int enabled, unsigned int connected);
 

--- a/libknet/onwire.c
+++ b/libknet/onwire.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2019 Red Hat, Inc.  All rights reserved.
+ *
+ * Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
+ *
+ * This software licensed under LGPL-2.0+
+ */
+
+#include "config.h"
+
+#include <sys/errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "crypto.h"
+#include "internals.h"
+#include "logging.h"
+#include "common.h"
+#include "transport_udp.h"
+#include "transport_sctp.h"
+
+/*
+ * unencrypted packet looks like:
+ *
+ * | ip | protocol  | knet_header | unencrypted data                                  |
+ * | onwire_len                                                                       |
+ * | proto_overhead |
+ *                  | data_len                                                        |
+ *                                | app MTU                                           |
+ *
+ * encrypted packet looks like (not to scale):
+ *
+ * | ip | protocol  | salt | crypto(knet_header | data)      | crypto_data_pad | hash |
+ * | onwire_len                                                                       |
+ * | proto_overhead |
+ *                  | data_len                                                        |
+ *                                              | app MTU    |
+ *
+ * knet_h->sec_block_size is >= 0 if encryption will pad the data
+ * knet_h->sec_salt_size is >= 0 if encryption is enabled
+ * knet_h->sec_hash_size is >= 0 if signing is enabled
+ */
+
+/*
+ * this function takes in the data that we would like to send
+ * and tells us the outgoing onwire data size with crypto and
+ * all the headers adjustment.
+ * calling thread needs to account for protocol overhead.
+ */
+
+size_t calc_data_outlen(knet_handle_t knet_h, size_t inlen)
+{
+	size_t outlen = inlen, pad_len = 0;
+
+	if (knet_h->sec_block_size) {
+		/*
+		 * if the crypto mechanism requires padding, calculate the padding
+		 * and add it back to outlen because that's what the crypto layer
+		 * would do.
+		 */
+		pad_len = knet_h->sec_block_size - (outlen % knet_h->sec_block_size);
+
+		outlen = outlen + pad_len;
+	}
+
+	return outlen + knet_h->sec_salt_size + knet_h->sec_hash_size;
+}
+
+/*
+ * this function takes in the data that we would like to send
+ * and tells us what is the real maximum data we can send
+ * accounting for headers and crypto
+ * calling thread needs to account for protocol overhead.
+ */
+
+size_t calc_max_data_outlen(knet_handle_t knet_h, size_t inlen)
+{
+	size_t outlen = inlen, pad_len = 0;
+
+	if (knet_h->sec_block_size) {
+		/*
+		 * drop both salt and hash, that leaves only the crypto data and padding
+		 * we need to calculate the padding based on the real encrypted data
+		 * that includes the knet_header.
+		 */
+		outlen = outlen - (knet_h->sec_salt_size + knet_h->sec_hash_size);
+
+		/*
+		 * if the crypto mechanism requires padding, calculate the padding
+		 * and remove it, to align the data.
+		 * NOTE: we need to remove pad_len + 1 because, based on testing,
+		 * if we send data that are already aligned to block_size, the
+		 * crypto implementations will add another block_size!
+		 * so we want to make sure that our data won't add an unnecessary
+		 * block_size that we need to remove later.
+		 */
+		pad_len = outlen % knet_h->sec_block_size;
+
+		outlen = outlen - (pad_len + 1);
+
+		/*
+		 * add both hash and salt size back, similar to padding above,
+		 * the crypto layer will add them to the outlen
+		 */
+		outlen = outlen + (knet_h->sec_salt_size + knet_h->sec_hash_size);
+	}
+
+	/*
+	 * drop KNET_HEADER_ALL_SIZE to provide a clean application MTU
+	 * and various crypto headers
+	 */
+	outlen = outlen - (KNET_HEADER_ALL_SIZE + knet_h->sec_salt_size + knet_h->sec_hash_size);
+
+	return outlen;
+}
+
+/*
+ * set the lowest possible value as failsafe for all links.
+ * KNET_PMTUD_MIN_MTU_V4 < KNET_PMTUD_MIN_MTU_V6
+ * KNET_PMTUD_OVERHEAD_V6 > KNET_PMTUD_OVERHEAD_V4
+ * KNET_PMTUD_SCTP_OVERHEAD > KNET_PMTUD_UDP_OVERHEAD
+ */
+
+size_t calc_min_mtu(knet_handle_t knet_h)
+{
+	return calc_max_data_outlen(knet_h, KNET_PMTUD_MIN_MTU_V4 - (KNET_PMTUD_OVERHEAD_V6 + KNET_PMTUD_SCTP_OVERHEAD));
+}

--- a/libknet/onwire.h
+++ b/libknet/onwire.h
@@ -120,7 +120,9 @@ struct knet_header_payload_ping {
 #define KNET_PMTUD_SIZE_V4 65535
 #define KNET_PMTUD_SIZE_V6 KNET_PMTUD_SIZE_V4
 
-/* These two get the protocol-specific overheads added to them */
+/*
+ * IPv4/IPv6 header size
+ */
 #define KNET_PMTUD_OVERHEAD_V4 20
 #define KNET_PMTUD_OVERHEAD_V6 40
 
@@ -198,5 +200,9 @@ struct knet_header {
 #define KNET_HEADER_PING_SIZE (KNET_HEADER_SIZE + sizeof(struct knet_header_payload_ping))
 #define KNET_HEADER_PMTUD_SIZE (KNET_HEADER_SIZE + sizeof(struct knet_header_payload_pmtud))
 #define KNET_HEADER_DATA_SIZE (KNET_HEADER_SIZE + sizeof(struct knet_header_payload_data))
+
+size_t calc_data_outlen(knet_handle_t knet_h, size_t inlen);
+size_t calc_max_data_outlen(knet_handle_t knet_h, size_t inlen);
+size_t calc_min_mtu(knet_handle_t knet_h);
 
 #endif

--- a/libknet/tests/Makefile.am
+++ b/libknet/tests/Makefile.am
@@ -38,6 +38,12 @@ int_checks		= \
 
 fun_checks		=
 
+# checks below need to be executed manually
+# or with a specifi environment
+
+long_run_checks		= \
+			  fun_pmtud_crypto_test
+
 benchmarks		= \
 			  knet_bench_test
 
@@ -45,6 +51,7 @@ noinst_PROGRAMS		= \
 			  api_knet_handle_new_limit_test \
 			  pckt_test \
 			  $(benchmarks) \
+			  $(long_run_checks) \
 			  $(check_PROGRAMS)
 
 noinst_SCRIPTS		= \
@@ -71,6 +78,7 @@ int_links_acl_ip_test_SOURCES = int_links_acl_ip.c \
 				../logging.c \
 				../netutils.c \
 				../threads_common.c \
+				../onwire.c \
 				../transports.c \
 				../transport_common.c \
 				../transport_loopback.c \
@@ -88,4 +96,9 @@ knet_bench_test_SOURCES	= knet_bench.c \
 			  ../logging.c \
 			  ../compat.c \
 			  ../transport_common.c \
-			  ../threads_common.c
+			  ../threads_common.c \
+			  ../onwire.c
+
+fun_pmtud_crypto_test_SOURCES = fun_pmtud_crypto.c \
+				test-common.c \
+				../onwire.c

--- a/libknet/tests/api-check.mk
+++ b/libknet/tests/api-check.mk
@@ -38,6 +38,7 @@ api_checks		= \
 			  api_knet_handle_pmtud_getfreq_test \
 			  api_knet_handle_enable_pmtud_notify_test \
 			  api_knet_handle_pmtud_get_test \
+			  api_knet_handle_pmtud_set_test \
 			  api_knet_host_add_test \
 			  api_knet_host_remove_test \
 			  api_knet_host_set_name_test \
@@ -171,6 +172,9 @@ api_knet_handle_enable_pmtud_notify_test_SOURCES = api_knet_handle_enable_pmtud_
 						   test-common.c
 
 api_knet_handle_pmtud_get_test_SOURCES = api_knet_handle_pmtud_get.c \
+					 test-common.c
+
+api_knet_handle_pmtud_set_test_SOURCES = api_knet_handle_pmtud_set.c \
 					 test-common.c
 
 api_knet_host_add_test_SOURCES = api_knet_host_add.c \

--- a/libknet/tests/api_knet_handle_pmtud_set.c
+++ b/libknet/tests/api_knet_handle_pmtud_set.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2016-2019 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
+ *
+ * This software licensed under GPL-2.0+
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "libknet.h"
+
+#include "internals.h"
+#include "test-common.h"
+
+static int private_data;
+
+static void sock_notify(void *pvt_data,
+			int datafd,
+			int8_t channel,
+			uint8_t tx_rx,
+			int error,
+			int errorno)
+{
+	return;
+}
+
+static void test(void)
+{
+	knet_handle_t knet_h;
+	int logfds[2];
+	unsigned int iface_mtu = 0, data_mtu;
+	int datafd = 0;
+	int8_t channel = 0;
+	struct sockaddr_storage lo;
+
+	if (make_local_sockaddr(&lo, 0) < 0) {
+		printf("Unable to convert loopback to sockaddr: %s\n", strerror(errno));
+		exit(FAIL);
+	}
+
+	printf("Test knet_handle_pmtud_set incorrect knet_h\n");
+
+	if ((!knet_handle_pmtud_set(NULL, iface_mtu)) || (errno != EINVAL)) {
+		printf("knet_handle_pmtud_set accepted invalid knet_h or returned incorrect error: %s\n", strerror(errno));
+		exit(FAIL);
+	}
+
+	setup_logpipes(logfds);
+
+	knet_h = knet_handle_start(logfds, KNET_LOG_DEBUG);
+
+	flush_logs(logfds[0], stdout);
+
+	iface_mtu = KNET_PMTUD_SIZE_V4 + 1;
+	printf("Test knet_handle_pmtud_set with wrong iface_mtu\n");
+	if ((!knet_handle_pmtud_set(knet_h, iface_mtu)) || (errno != EINVAL)) {
+		printf("knet_handle_pmtud_set accepted invalid data_mtu or returned incorrect error: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	if (knet_handle_enable_sock_notify(knet_h, &private_data, sock_notify) < 0) {
+		printf("knet_handle_enable_sock_notify failed: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+        }
+
+	datafd = 0;
+	channel = -1;
+
+	if (knet_handle_add_datafd(knet_h, &datafd, &channel) < 0) {
+		printf("knet_handle_add_datafd failed: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	if (knet_host_add(knet_h, 1) < 0) {
+		printf("knet_host_add failed: %s\n", strerror(errno));
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	if (knet_link_set_config(knet_h, 1, 0, KNET_TRANSPORT_UDP, &lo, &lo, 0) < 0) {
+		printf("Unable to configure link: %s\n", strerror(errno));
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	if (knet_link_set_pong_count(knet_h, 1, 0, 1) < 0) {
+		printf("knet_link_set_pong_count failed: %s\n", strerror(errno));
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	if (knet_link_set_enable(knet_h, 1, 0, 1) < 0) {
+		printf("knet_link_set_enable failed: %s\n", strerror(errno));
+		knet_link_clear_config(knet_h, 1, 0);
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	if (wait_for_host(knet_h, 1, 4, logfds[0], stdout) < 0) {
+		printf("timeout waiting for host to be reachable");
+		knet_link_set_enable(knet_h, 1, 0, 0);
+		knet_link_clear_config(knet_h, 1, 0);
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	flush_logs(logfds[0], stdout);
+
+	if (knet_handle_pmtud_get(knet_h, &data_mtu) < 0) {
+		printf("knet_handle_pmtud_get failed error: %s\n", strerror(errno));
+		knet_link_set_enable(knet_h, 1, 0, 0);
+		knet_link_clear_config(knet_h, 1, 0);
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	/*
+	 * 28 = IP (20) + UDP (8)
+	 */
+	iface_mtu = data_mtu + 28 + KNET_HEADER_ALL_SIZE - 64;
+	printf("Test knet_handle_pmtud_set with iface_mtu %u\n", iface_mtu);
+
+	if (knet_handle_pmtud_set(knet_h, iface_mtu) < 0) {
+		printf("knet_handle_pmtud_set failed error: %s\n", strerror(errno));
+		knet_link_set_enable(knet_h, 1, 0, 0);
+		knet_link_clear_config(knet_h, 1, 0);
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	/*
+	 * wait for PMTUd to pick up the change
+	 */
+	sleep(1);
+	flush_logs(logfds[0], stdout);
+
+	if (knet_h->data_mtu != data_mtu - 64) {
+		printf("knet_handle_pmtud_set failed to set the value\n");
+		knet_link_set_enable(knet_h, 1, 0, 0);
+		knet_link_clear_config(knet_h, 1, 0);
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	printf("Test knet_handle_pmtud_set with iface_mtu 0\n");
+	if (knet_handle_pmtud_set(knet_h, 0) < 0) {
+		printf("knet_handle_pmtud_set failed error: %s\n", strerror(errno));
+		knet_link_set_enable(knet_h, 1, 0, 0);
+		knet_link_clear_config(knet_h, 1, 0);
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	/*
+	 * wait for PMTUd to pick up the change
+	 */
+	sleep(1);
+	flush_logs(logfds[0], stdout);
+
+	if (knet_h->data_mtu != data_mtu) {
+		printf("knet_handle_pmtud_set failed to redetect MTU\n");
+		knet_link_set_enable(knet_h, 1, 0, 0);
+		knet_link_clear_config(knet_h, 1, 0);
+		knet_host_remove(knet_h, 1);
+		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	knet_link_set_enable(knet_h, 1, 0, 0);
+	knet_link_clear_config(knet_h, 1, 0);
+	knet_host_remove(knet_h, 1);
+	knet_handle_free(knet_h);
+	flush_logs(logfds[0], stdout);
+	close_logpipes(logfds);
+}
+
+int main(int argc, char *argv[])
+{
+	test();
+
+	return PASS;
+}

--- a/libknet/threads_common.c
+++ b/libknet/threads_common.c
@@ -223,7 +223,7 @@ void force_pmtud_run(knet_handle_t knet_h, uint8_t subsystem, uint8_t reset_mtu)
 {
 	if (reset_mtu) {
 		log_debug(knet_h, subsystem, "PMTUd has been reset to default");
-		knet_h->data_mtu = KNET_PMTUD_MIN_MTU_V4 - KNET_HEADER_ALL_SIZE - knet_h->sec_header_size;
+		knet_h->data_mtu = calc_min_mtu(knet_h);
 		if (knet_h->pmtud_notify_fn) {
 			knet_h->pmtud_notify_fn(knet_h->pmtud_notify_fn_private_data,
 						knet_h->data_mtu);

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -25,16 +25,16 @@
 static int _handle_check_link_pmtud(knet_handle_t knet_h, struct knet_host *dst_host, struct knet_link *dst_link)
 {
 	int err, ret, savederrno, mutex_retry_limit, failsafe, use_kernel_mtu, warn_once;
-	uint32_t kernel_mtu; /* record kernel_mtu from EMSGSIZE */
-	size_t onwire_len;   /* current packet onwire size */
-	size_t overhead_len; /* onwire packet overhead (protocol based) */
-	size_t max_mtu_len;  /* max mtu for protocol */
-	size_t data_len;     /* how much data we can send in the packet
-			      * generally would be onwire_len - overhead_len
-			      * needs to be adjusted for crypto
-			      */
-	size_t pad_len;	     /* crypto packet pad size, needs to move into crypto.c callbacks */
-	ssize_t len;	     /* len of what we were able to sendto onwire */
+	uint32_t kernel_mtu;		/* record kernel_mtu from EMSGSIZE */
+	size_t onwire_len;   		/* current packet onwire size */
+	size_t ipproto_overhead_len;	/* onwire packet overhead (protocol based) */
+	size_t max_mtu_len;		/* max mtu for protocol */
+	size_t data_len;		/* how much data we can send in the packet
+					 * generally would be onwire_len - ipproto_overhead_len
+					 * needs to be adjusted for crypto
+					 */
+	size_t app_mtu_len;		/* real data that we can send onwire */
+	ssize_t len;			/* len of what we were able to sendto onwire */
 
 	struct timespec ts;
 	unsigned long long pong_timeout_adj_tmp;
@@ -45,26 +45,25 @@ static int _handle_check_link_pmtud(knet_handle_t knet_h, struct knet_host *dst_
 	mutex_retry_limit = 0;
 	failsafe = 0;
 
-	dst_link->last_bad_mtu = 0;
-
 	knet_h->pmtudbuf->khp_pmtud_link = dst_link->link_id;
 
 	switch (dst_link->dst_addr.ss_family) {
 		case AF_INET6:
 			max_mtu_len = KNET_PMTUD_SIZE_V6;
-			overhead_len = KNET_PMTUD_OVERHEAD_V6 + dst_link->proto_overhead;
-			dst_link->last_good_mtu = dst_link->last_ping_size + overhead_len;
+			ipproto_overhead_len = KNET_PMTUD_OVERHEAD_V6 + dst_link->proto_overhead;
 			break;
 		case AF_INET:
 			max_mtu_len = KNET_PMTUD_SIZE_V4;
-			overhead_len = KNET_PMTUD_OVERHEAD_V4 + dst_link->proto_overhead;
-			dst_link->last_good_mtu = dst_link->last_ping_size + overhead_len;
+			ipproto_overhead_len = KNET_PMTUD_OVERHEAD_V4 + dst_link->proto_overhead;
 			break;
 		default:
 			log_debug(knet_h, KNET_SUB_PMTUD, "PMTUD aborted, unknown protocol");
 			return -1;
 			break;
 	}
+
+	dst_link->last_bad_mtu = 0;
+	dst_link->last_good_mtu = dst_link->last_ping_size + ipproto_overhead_len;
 
 	/*
 	 * discovery starts from the top because kernel will
@@ -92,107 +91,39 @@ restart:
 	}
 
 	/*
-	 * unencrypted packet looks like:
-	 *
-	 * | ip | protocol | knet_header | unencrypted data                                  |
-	 * | onwire_len                                                                      |
-	 * | overhead_len  |
-	 *                 | data_len                                                        |
-	 *                               | app MTU                                           |
-	 *
-	 * encrypted packet looks like (not to scale):
-	 *
-	 * | ip | protocol | salt | crypto(knet_header | data)      | crypto_data_pad | hash |
-	 * | onwire_len                                                                      |
-	 * | overhead_len  |
-	 *                 | data_len                                                        |
-	 *                                             | app MTU    |
-	 *
-	 * knet_h->sec_block_size is >= 0 if encryption will pad the data
-	 * knet_h->sec_salt_size is >= 0 if encryption is enabled
-	 * knet_h->sec_hash_size is >= 0 if signing is enabled
+	 * common to all packets
 	 */
 
 	/*
-	 * common to all packets
+	 * calculate the application MTU based on current onwire_len minus ipproto_overhead_len
 	 */
-	data_len = onwire_len - overhead_len;
+
+	app_mtu_len = calc_max_data_outlen(knet_h, onwire_len - ipproto_overhead_len);
+
+	/*
+	 * recalculate onwire len back that might be different based
+	 * on data padding from crypto layer.
+	 */
+
+	onwire_len = calc_data_outlen(knet_h, app_mtu_len + KNET_HEADER_ALL_SIZE) + ipproto_overhead_len;
+
+	/*
+	 * calculate the size of what we need to send to sendto(2).
+	 * see also onwire.c for packet format explanation.
+	 */
+	data_len = app_mtu_len + knet_h->sec_hash_size + knet_h->sec_salt_size + KNET_HEADER_ALL_SIZE;
 
 	if (knet_h->crypto_instance) {
-
-realign:
-		if (knet_h->sec_block_size) {
-
-			/*
-			 * drop both salt and hash, that leaves only the crypto data and padding
-			 * we need to calculate the padding based on the real encrypted data.
-			 */
-			data_len = data_len - (knet_h->sec_salt_size + knet_h->sec_hash_size);
-
-			/*
-			 * if the crypto mechanism requires padding, calculate the padding
-			 * and add it back to data_len because that's what the crypto layer
-			 * would do.
-			 */
-			pad_len = knet_h->sec_block_size - (data_len % knet_h->sec_block_size);
-
-			/*
-			 * if are at the boundary, reset padding
-			 */
-			if (pad_len == knet_h->sec_block_size) {
-				pad_len = 0;
-			}
-			data_len = data_len + pad_len;
-
-			/*
-			 * if our current data_len is higher than max_mtu_len
-			 * then we need to reduce by padding size (that is our
-			 * increment / decrement value)
-			 *
-			 * this generally happens only on the first PMTUd run
-			 */
-			while (data_len + overhead_len >= max_mtu_len) {
-				data_len = data_len - knet_h->sec_block_size;
-			}
-
-			/*
-			 * add both hash and salt size back, similar to padding above,
-			 * the crypto layer will add them to the data_len
-			 */
-			data_len = data_len + (knet_h->sec_salt_size + knet_h->sec_hash_size);
-		}
-
-		if (dst_link->last_bad_mtu) {
-			if (data_len + overhead_len >= dst_link->last_bad_mtu) {
-				/*
-				 * reduce data_len to something lower than last_bad_mtu, overhead_len
-				 * and sec_block_size (decrementing step) - 1 (granularity)
-				 */
-				data_len = dst_link->last_bad_mtu - overhead_len - knet_h->sec_block_size - 1;
-				if (knet_h->sec_block_size) {
-					/*
-					 * make sure that data_len is aligned to the sec_block_size boundary
-					 */
-					goto realign;
-				}
-			}
-		}
-
-		if (data_len < (knet_h->sec_hash_size + knet_h->sec_salt_size + knet_h->sec_block_size) + 1) {
+		if (data_len < (knet_h->sec_hash_size + knet_h->sec_salt_size) + 1) {
 			log_debug(knet_h, KNET_SUB_PMTUD, "Aborting PMTUD process: link mtu smaller than crypto header detected (link might have been disconnected)");
 			return -1;
 		}
 
-		/*
-		 * recalculate onwire_len based on crypto information
-		 * and place it in the PMTUd packet info
-		 */
-		onwire_len = data_len + overhead_len;
 		knet_h->pmtudbuf->khp_pmtud_size = onwire_len;
 
 		if (crypto_encrypt_and_sign(knet_h,
 					    (const unsigned char *)knet_h->pmtudbuf,
-					    data_len - (knet_h->sec_hash_size + knet_h->sec_salt_size + knet_h->sec_block_size),
+					    data_len - (knet_h->sec_hash_size + knet_h->sec_salt_size),
 					    knet_h->pmtudbuf_crypt,
 					    (ssize_t *)&data_len) < 0) {
 			log_debug(knet_h, KNET_SUB_PMTUD, "Unable to crypto pmtud packet");
@@ -201,11 +132,8 @@ realign:
 
 		outbuf = knet_h->pmtudbuf_crypt;
 		knet_h->stats_extra.tx_crypt_pmtu_packets++;
-
 	} else {
-
 		knet_h->pmtudbuf->khp_pmtud_size = onwire_len;
-
 	}
 
 	/* link has gone down, aborting pmtud */
@@ -421,7 +349,7 @@ retry:
 				/*
 				 * account for IP overhead, knet headers and crypto in PMTU calculation
 				 */
-				dst_link->status.mtu = onwire_len - dst_link->status.proto_overhead;
+				dst_link->status.mtu = calc_max_data_outlen(knet_h, onwire_len - ipproto_overhead_len);
 				pthread_mutex_unlock(&knet_h->pmtud_mutex);
 				return 0;
 			}
@@ -441,7 +369,7 @@ retry:
 	goto restart;
 }
 
-static int _handle_check_pmtud(knet_handle_t knet_h, struct knet_host *dst_host, struct knet_link *dst_link, unsigned int *min_mtu, int force_run)
+static int _handle_check_pmtud(knet_handle_t knet_h, struct knet_host *dst_host, struct knet_link *dst_link, int force_run)
 {
 	uint8_t saved_valid_pmtud;
 	unsigned int saved_pmtud;
@@ -459,17 +387,22 @@ static int _handle_check_pmtud(knet_handle_t knet_h, struct knet_host *dst_host,
 		timespec_diff(dst_link->pmtud_last, clock_now, &diff_pmtud);
 
 		if (diff_pmtud < interval) {
-			*min_mtu = dst_link->status.mtu;
 			return dst_link->has_valid_mtu;
 		}
 	}
 
+	/*
+	 * status.proto_overhead should include all IP/(UDP|SCTP)/knet headers
+	 *
+	 * please note that it is not the same as link->proto_overhead that
+	 * includes only either UDP or SCTP (at the moment) overhead.
+	 */
 	switch (dst_link->dst_addr.ss_family) {
 		case AF_INET6:
-			dst_link->status.proto_overhead = KNET_PMTUD_OVERHEAD_V6 + dst_link->proto_overhead + KNET_HEADER_ALL_SIZE + knet_h->sec_header_size;
+			dst_link->status.proto_overhead = KNET_PMTUD_OVERHEAD_V6 + dst_link->proto_overhead + KNET_HEADER_ALL_SIZE + knet_h->sec_hash_size + knet_h->sec_salt_size;
 			break;
 		case AF_INET:
-			dst_link->status.proto_overhead = KNET_PMTUD_OVERHEAD_V4 + dst_link->proto_overhead + KNET_HEADER_ALL_SIZE + knet_h->sec_header_size;
+			dst_link->status.proto_overhead = KNET_PMTUD_OVERHEAD_V4 + dst_link->proto_overhead + KNET_HEADER_ALL_SIZE + knet_h->sec_hash_size + knet_h->sec_salt_size;
 			break;
 	}
 
@@ -490,26 +423,6 @@ static int _handle_check_pmtud(knet_handle_t knet_h, struct knet_host *dst_host,
 		dst_link->has_valid_mtu = 0;
 	} else {
 		dst_link->has_valid_mtu = 1;
-		switch (dst_link->dst_addr.ss_family) {
-			case AF_INET6:
-				if (((dst_link->status.mtu + dst_link->status.proto_overhead) < KNET_PMTUD_MIN_MTU_V6) ||
-				    ((dst_link->status.mtu + dst_link->status.proto_overhead) > KNET_PMTUD_SIZE_V6)) {
-					log_debug(knet_h, KNET_SUB_PMTUD,
-						  "PMTUD detected an IPv6 MTU out of bound value (%u) for host: %u link: %u.",
-						  dst_link->status.mtu + dst_link->status.proto_overhead, dst_host->host_id, dst_link->link_id);
-					dst_link->has_valid_mtu = 0;
-				}
-				break;
-			case AF_INET:
-				if (((dst_link->status.mtu + dst_link->status.proto_overhead) < KNET_PMTUD_MIN_MTU_V4) ||
-				    ((dst_link->status.mtu + dst_link->status.proto_overhead) > KNET_PMTUD_SIZE_V4)) {
-					log_debug(knet_h, KNET_SUB_PMTUD,
-						  "PMTUD detected an IPv4 MTU out of bound value (%u) for host: %u link: %u.",
-						  dst_link->status.mtu + dst_link->status.proto_overhead, dst_host->host_id, dst_link->link_id);
-					dst_link->has_valid_mtu = 0;
-				}
-				break;
-		}
 		if (dst_link->has_valid_mtu) {
 			if ((saved_pmtud) && (saved_pmtud != dst_link->status.mtu)) {
 				log_info(knet_h, KNET_SUB_PMTUD, "PMTUD link change for host: %u link: %u from %u to %u",
@@ -517,9 +430,6 @@ static int _handle_check_pmtud(knet_handle_t knet_h, struct knet_host *dst_host,
 			}
 			log_debug(knet_h, KNET_SUB_PMTUD, "PMTUD completed for host: %u link: %u current link mtu: %u",
 				  dst_host->host_id, dst_link->link_id, dst_link->status.mtu);
-			if (dst_link->status.mtu < *min_mtu) {
-				*min_mtu = dst_link->status.mtu;
-			}
 
 			/*
 			 * set pmtud_last, if we can, after we are done with the PMTUd process
@@ -545,14 +455,14 @@ void *_handle_pmtud_link_thread(void *data)
 	struct knet_host *dst_host;
 	struct knet_link *dst_link;
 	int link_idx;
-	unsigned int min_mtu, have_mtu;
+	unsigned int have_mtu;
 	unsigned int lower_mtu;
 	int link_has_mtu;
 	int force_run = 0;
 
 	set_thread_status(knet_h, KNET_THREAD_PMTUD, KNET_THREAD_STARTED);
 
-	knet_h->data_mtu = KNET_PMTUD_MIN_MTU_V4 - KNET_HEADER_ALL_SIZE - knet_h->sec_header_size;
+	knet_h->data_mtu = calc_min_mtu(knet_h);
 
 	/* preparing pmtu buffer */
 	knet_h->pmtudbuf->kh_version = KNET_HEADER_VERSION;
@@ -582,7 +492,6 @@ void *_handle_pmtud_link_thread(void *data)
 		}
 
 		lower_mtu = KNET_PMTUD_SIZE_V4;
-		min_mtu = KNET_PMTUD_SIZE_V4 - KNET_HEADER_ALL_SIZE - knet_h->sec_header_size;
 		have_mtu = 0;
 
 		for (dst_host = knet_h->host_head; dst_host != NULL; dst_host = dst_host->next) {
@@ -597,14 +506,14 @@ void *_handle_pmtud_link_thread(void *data)
 				     (dst_link->status.dynconnected != 1)))
 					continue;
 
-				link_has_mtu = _handle_check_pmtud(knet_h, dst_host, dst_link, &min_mtu, force_run);
+				link_has_mtu = _handle_check_pmtud(knet_h, dst_host, dst_link, force_run);
 				if (errno == EDEADLK) {
 					goto out_unlock;
 				}
 				if (link_has_mtu) {
 					have_mtu = 1;
-					if (min_mtu < lower_mtu) {
-						lower_mtu = min_mtu;
+					if (dst_link->status.mtu < lower_mtu) {
+						lower_mtu = dst_link->status.mtu;
 					}
 				}
 			}

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -36,8 +36,9 @@ static int _handle_check_link_pmtud(knet_handle_t knet_h, struct knet_host *dst_
 	size_t app_mtu_len;		/* real data that we can send onwire */
 	ssize_t len;			/* len of what we were able to sendto onwire */
 
-	struct timespec ts;
-	unsigned long long pong_timeout_adj_tmp;
+	struct timespec ts, pmtud_crypto_start_ts, pmtud_crypto_stop_ts;
+	unsigned long long pong_timeout_adj_tmp, timediff;
+	int pmtud_crypto_reduce = 1;
 	unsigned char *outbuf = (unsigned char *)knet_h->pmtudbuf;
 
 	warn_once = 0;
@@ -243,6 +244,15 @@ retry:
 		}
 
 		/*
+		 * non fatal, we can wait the next round to reduce the
+		 * multiplier
+		 */
+		if (clock_gettime(CLOCK_MONOTONIC, &pmtud_crypto_start_ts) < 0) {
+			log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get current time: %s", strerror(errno));
+			pmtud_crypto_reduce = 0;
+		}
+
+		/*
 		 * set PMTUd reply timeout to match pong_timeout on a given link
 		 *
 		 * math: internally pong_timeout is expressed in microseconds, while
@@ -261,7 +271,7 @@ retry:
 			/*
 			 * crypto, under pressure, is a royal PITA
 			 */
-			pong_timeout_adj_tmp = dst_link->pong_timeout_adj * 2;
+			pong_timeout_adj_tmp = dst_link->pong_timeout_adj * dst_link->pmtud_crypto_timeout_multiplier;
 		} else {
 			pong_timeout_adj_tmp = dst_link->pong_timeout_adj;
 		}
@@ -299,6 +309,17 @@ retry:
 
 		if (ret) {
 			if (ret == ETIMEDOUT) {
+				if ((knet_h->crypto_instance) && (dst_link->pmtud_crypto_timeout_multiplier < KNET_LINK_PMTUD_CRYPTO_TIMEOUT_MULTIPLIER_MAX)) {
+					dst_link->pmtud_crypto_timeout_multiplier = dst_link->pmtud_crypto_timeout_multiplier * 2;
+					pmtud_crypto_reduce = 0;
+					log_debug(knet_h, KNET_SUB_PMTUD,
+							"Increasing PMTUd response timeout multiplier to (%u) for host %u link: %u",
+							dst_link->pmtud_crypto_timeout_multiplier,
+							dst_host->host_id,
+							dst_link->link_id);
+					pthread_mutex_unlock(&knet_h->pmtud_mutex);
+					goto restart;
+				}
 				if (!warn_once) {
 					log_warn(knet_h, KNET_SUB_PMTUD,
 							"possible MTU misconfiguration detected. "
@@ -324,6 +345,23 @@ retry:
 				}
 				mutex_retry_limit++;
 				goto restart;
+			}
+		}
+
+		if ((knet_h->crypto_instance) && (pmtud_crypto_reduce == 1) &&
+		    (dst_link->pmtud_crypto_timeout_multiplier > KNET_LINK_PMTUD_CRYPTO_TIMEOUT_MULTIPLIER_MIN)) {
+			if (!clock_gettime(CLOCK_MONOTONIC, &pmtud_crypto_stop_ts)) {
+				timespec_diff(pmtud_crypto_start_ts, pmtud_crypto_stop_ts, &timediff);
+				if (((pong_timeout_adj_tmp * 1000) / 2) > timediff) {
+					dst_link->pmtud_crypto_timeout_multiplier = dst_link->pmtud_crypto_timeout_multiplier / 2;
+					log_debug(knet_h, KNET_SUB_PMTUD,
+							"Decreasing PMTUd response timeout multiplier to (%u) for host %u link: %u",
+							dst_link->pmtud_crypto_timeout_multiplier,
+							dst_host->host_id,
+							dst_link->link_id);
+				}
+			} else {
+				log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get current time: %s", strerror(errno));
 			}
 		}
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -57,6 +57,7 @@ knet_man3_MANS = \
 		knet_handle_get_transport_reconnect_interval.3 \
 		knet_handle_new.3 \
 		knet_handle_pmtud_get.3 \
+		knet_handle_pmtud_set.3 \
 		knet_handle_pmtud_getfreq.3 \
 		knet_handle_pmtud_setfreq.3 \
 		knet_handle_remove_datafd.3 \


### PR DESCRIPTION
internal changes:
- drop the concept of sec_header_size that was completely wrong
  and unnecessary
- bump crypto API to version 3 due to the above change
- clarify the difference between link->proto_overhead and
  link->status->proto_overhead. We cannot rename the status
  one as it would also change ABI.
- add onwire.c with documentation on the packet format
  and what various len(s) mean in context.
- add 3 new functions to calculate MTUs back and forth
  and use them around, hopefully with enough clarification
  on why things are done in a given way.
- heavily change thread_pmtud.c to use those new facilities.
- fix major calculation issues when using crypto (non-crypto
  was not affected by the problem).
- fix checks around to make sure they match the new math.
- fix padding calculation.

user visible changes:
- Global MTU is now calculated properly when using crypto
  and values will be in general bigger than before due
  to incorrect padding calculation in the previous implementation.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>