### PR TITLE
[pmtud] switch to use async version of dstcache update due to locking…

### DIFF
--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -503,7 +503,7 @@ static int _handle_check_pmtud(knet_handle_t knet_h, struct knet_host *dst_host,
 	}
 
 	if (saved_valid_pmtud != dst_link->has_valid_mtu) {
-		_host_dstcache_update_sync(knet_h, dst_host);
+		_host_dstcache_update_async(knet_h, dst_host);
 	}
 
 	return dst_link->has_valid_mtu;


### PR DESCRIPTION
… context (read vs write)

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>