### PR TITLE
[links] fix memory corryption of link structure

### DIFF
--- a/libknet/links.c
+++ b/libknet/links.c
@@ -62,13 +62,13 @@ int _link_updown(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t link_id,
 	if (connected) {
 		time(&link->status.stats.last_up_times[link->status.stats.last_up_time_index]);
 		link->status.stats.up_count++;
-		if (++link->status.stats.last_up_time_index > MAX_LINK_EVENTS) {
+		if (++link->status.stats.last_up_time_index >= MAX_LINK_EVENTS) {
 			link->status.stats.last_up_time_index = 0;
 		}
 	} else {
 		time(&link->status.stats.last_down_times[link->status.stats.last_down_time_index]);
 		link->status.stats.down_count++;
-		if (++link->status.stats.last_down_time_index > MAX_LINK_EVENTS) {
+		if (++link->status.stats.last_down_time_index >= MAX_LINK_EVENTS) {
 			link->status.stats.last_down_time_index = 0;
 		}
 	}


### PR DESCRIPTION
the index would overflow the buffer and overwrite data in the link
structure. Depending on what was written the cluster could fall
apart in many ways, from crashing, to hung.

Fixes: https://github.com/kronosnet/kronosnet/issues/255

thanks to the proxmox developers and community for reporting the issue
and for all the help reproducing / debugging the problem.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>