### PR TITLE
doxyxml: print_param: fix heap-buffer-overflow on read

### DIFF
--- a/man/doxyxml.c
+++ b/man/doxyxml.c
@@ -342,17 +342,18 @@ static void print_param(FILE *manfile, struct param_info *pi, int field_width, i
 {
 	char *asterisks = "  ";
 	char *type = pi->paramtype;
+	int typelength = strlen(type);
 
 	/* Reformat pointer params so they look nicer */
-	if (pi->paramtype[strlen(pi->paramtype)-1] == '*') {
+	if (typelength > 0 && pi->paramtype[typelength-1] == '*') {
 		asterisks=" *";
 		type = strdup(pi->paramtype);
-		type[strlen(type)-1] = '\0';
+		type[typelength-1] = '\0';
 
 		/* Cope with double pointers */
-		if (pi->paramtype[strlen(type)-1] == '*') {
+		if (typelength > 1 && pi->paramtype[typelength-2] == '*') {
 			asterisks="**";
-			type[strlen(type)-1] = '\0';
+			type[typelength-2] = '\0';
 		}
 	}
 


### PR DESCRIPTION
in read_struct we can get the pi->paramtype assigned with:
> pi->paramtype = type?strdup(type):strdup("");

And in print_param we then always check the last character by getting
the strlen and subtracting one. But in the case where either type was
NULL and we assigned an empty string, or type wasn't null but
pointing to an empty string we ran into an read-heap-buffer-overflow
as here strlen is zero, and so we the first if branch evaluated to
> if (pi->paramtype[-1] == '*') {
which isn't valid. Depending on the OS, protection of surrounding
area due to said OS or the compiler, this can crash the program.

Similar issue was the case for the next check for double pointers,
here for all strings with strlen < 2.

To solve this get the strlen early and check if we cannot underflow
before doing the real read.

Signed-off-by: Thomas Lamprecht <t.lamprecht@proxmox.com>