### PR TITLE
[tests] mark array as static

### DIFF
--- a/libknet/tests/int_links_acl_ip.c
+++ b/libknet/tests/int_links_acl_ip.c
@@ -76,7 +76,7 @@ static int read_2ip(const char *buf, const char *delim, struct sockaddr_storage 
  * ipcheck_validate calls
  */
 
-const char *rules[100] = {
+static const char *rules[100] = {
 	/*
 	 * ipv4
 	 */
@@ -188,7 +188,7 @@ static int default_rules(int load)
 	return 0;
 }
 
-const char *tests[100] = {
+static const char *tests[100] = {
 	/*
 	 * ipv4
 	 */
@@ -209,7 +209,7 @@ const char *tests[100] = {
 	"A3ffe:1::1:1"
 };
 
-const char *after_insert_tests[100] = {
+static const char *after_insert_tests[100] = {
 	/*
 	 * ipv4
 	 */


### PR DESCRIPTION
fixes an odd segfault when running the test on ppc when built with clang

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>