### PR TITLE
[udp] don't make socket spin if a network I/F is down

### DIFF
--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -403,6 +403,12 @@ int udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, 
 			log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is overloaded. Slowing TX down", sockfd);
 #endif
 			usleep(knet_h->threads_timer_res / 16);
+		}
+		if (recv_errno == ENETUNREACH) {
+#ifdef DEBUG
+			log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is unreachable", sockfd);
+#endif
+			usleep(knet_h->threads_timer_res / 16);
 		} else {
 			read_errs_from_sock(knet_h, sockfd);
 		}


### PR DESCRIPTION
UDP treats ENETUNREACH as a temporary error and just retries,
but this causes the TX thread to spin just doing sendto(), therefore
blocking all other traffic.

(To reproduce this try starting corosync with 2 links configured in
corosync.conf but only one of them configured to the 'right' address
- it will spin in a tight loop and need to be killed with -9)

SCTP does not seem to suffer from this.