### PR TITLE
[udp] Better fix for -ENETUNREACH

### DIFF
--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -395,16 +395,18 @@ int udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, 
 			read_errs_from_sock(knet_h, sockfd);
 			return 0;
 		}
-		if (recv_errno == EINVAL || recv_errno == EPERM) {
+		if ((recv_errno == EINVAL) || (recv_errno == EPERM) ||
+		    (recv_errno == ENETUNREACH) || (recv_errno == ENETDOWN)) {
+#ifdef DEBUG
+			if ((recv_errno == ENETUNREACH) || (recv_errno == ENETDOWN)) {
+				log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is unreachable.", sockfd);
+			}
+#endif
 			return -1;
 		}
-		if ((recv_errno == ENOBUFS) || (recv_errno == EAGAIN) || (recv_errno == ENETUNREACH)) {
+		if ((recv_errno == ENOBUFS) || (recv_errno == EAGAIN)) {
 #ifdef DEBUG
-			if (recv_errno == ENETUNREACH) {
-				log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is unreachable", sockfd);
-			} else {
-				log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is overloaded. Slowing TX down", sockfd);
-			}
+			log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is overloaded. Slowing TX down", sockfd);
 #endif
 			usleep(knet_h->threads_timer_res / 16);
 		} else {


### PR DESCRIPTION
This fix for the ENETUNREACH problem works better than the last one
in that it also works with Linux kernels > 5.0.0 (which return
-ENETUNREACH) if an interfaces is brought down, and also on FreeBSD
which returns ENETDOWN.