### PR TITLE
[links] kill redundant latency in link status and move it to stats

### DIFF
--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -66,7 +66,6 @@ struct knet_link {
 	unsigned long long pong_timeout_adj;	/* timeout adjusted for latency */
 	uint8_t pong_timeout_backoff;		/* see link.h for definition */
 	unsigned int latency_max_samples;	/* precision */
-	unsigned int latency_cur_samples;
 	uint8_t pong_count;			/* how many ping/pong to send/receive before link is up */
 	uint64_t flags;
 	/* status */

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -1962,9 +1962,6 @@ int knet_link_get_link_list(knet_handle_t knet_h, knet_node_id_t host_id,
  * dynconnected          the link has dynamic ip on the other end, and
  *                       we can see the other host is sending pings to us.
  *
- * latency               average latency of this link
- *                       see also knet_link_set/get_timeout.
- *
  * pong_last             if the link is down, this value tells us how long
  *                       ago this link was active. A value of 0 means that the link
  *                       has never been active.
@@ -2042,7 +2039,6 @@ struct knet_link_status {
 	uint8_t enabled;	        /* link is configured and admin enabled for traffic */
 	uint8_t connected;              /* link is connected for data (local view) */
 	uint8_t dynconnected;	        /* link has been activated by remote dynip */
-	unsigned long long latency;	/* average latency computed by fix/exp */
 	struct timespec pong_last;
 	unsigned int mtu;		/* current detected MTU on this link */
 	unsigned int proto_overhead;    /* contains the size of the IP protocol, knet headers and

--- a/libknet/links.c
+++ b/libknet/links.c
@@ -261,7 +261,7 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	link->pong_timeout_backoff = KNET_LINK_PONG_TIMEOUT_BACKOFF;
 	link->pong_timeout_adj = link->pong_timeout * link->pong_timeout_backoff; /* microseconds */
 	link->latency_max_samples = KNET_LINK_DEFAULT_PING_PRECISION;
-	link->latency_cur_samples = 0;
+	link->status.stats.latency_samples = 0;
 	link->flags = flags;
 
 	savederrno = pthread_mutex_init(&link->link_stats_mutex, NULL);

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -190,7 +190,7 @@ static void _adjust_pong_timeouts(knet_handle_t knet_h)
 				dst_link->pong_timeout_backoff--;
 			}
 
-			dst_link->pong_timeout_adj = (dst_link->pong_timeout * dst_link->pong_timeout_backoff) + (dst_link->status.latency * KNET_LINK_PONG_TIMEOUT_LAT_MUL);
+			dst_link->pong_timeout_adj = (dst_link->pong_timeout * dst_link->pong_timeout_backoff) + (dst_link->status.stats.latency_ave * KNET_LINK_PONG_TIMEOUT_LAT_MUL);
 		}
 	}
 


### PR DESCRIPTION
this is an ABI breakage. Soname change was already done a while back for master

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>