### PR TITLE
Enhance prio description of POLICY_PASSIVE

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -1151,7 +1151,7 @@ int knet_host_get_host_list(knet_handle_t knet_h,
  * policy   - there are currently 3 kind of simple switching policies
  *            based on link configuration.
  *            KNET_LINK_POLICY_PASSIVE - the active link with the highest
- *                                       priority will be used.
+ *                                       priority (highest number) will be used.
  *                                       if one or more active links share
  *                                       the same priority, the one with
  *                                       lowest link_id will be used.


### PR DESCRIPTION
Some users found description of POLICY_PASSIVE priority confusing
(probably because "priority" word is too overloaded) so add
some redundancy to make description unambiguous.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>