### PR TITLE
[build] make sure to use correct libqb include files across

### DIFF
--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -87,7 +87,9 @@ lib_LTLIBRARIES		= libknet.la
 
 libknet_la_SOURCES	= $(sources)
 
-libknet_la_CFLAGS	= $(AM_CFLAGS) $(libqb_CFLAGS) $(PTHREAD_CFLAGS)
+AM_CFLAGS		+= $(libqb_CFLAGS)
+
+libknet_la_CFLAGS	= $(AM_CFLAGS) $(PTHREAD_CFLAGS)
 
 EXTRA_libknet_la_DEPENDENCIES	= $(SYMFILE)
 


### PR DESCRIPTION
apparently header includes are not propagate the same way as clang on linux

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>