### PR TITLE
[openssl] allow use of deprecated HMAC interface with openssl 3.0

### DIFF
--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -9,6 +9,18 @@
 
 #include "config.h"
 
+/*
+ * allow to build with openssl 3.0 that has deprecated
+ * use of direct access to HMAC API.
+ *
+ * knet will require some heavy rewrite to port to 3.0,
+ * but it clashes with the re-key feature branch.
+ *
+ * use path of less resistance for now, then we will
+ * port at a later stage.
+ */
+#define OPENSSL_API_COMPAT 0x1010000L
+
 #include <string.h>
 #include <errno.h>
 #include <dlfcn.h>


### PR DESCRIPTION
Port will be done after rekey feature is complete (too much code conflict atm)

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>