### PR TITLE
tests: use callbacks to wait for nodes

### DIFF
--- a/libknet/tests/fun_config_crypto.c
+++ b/libknet/tests/fun_config_crypto.c
@@ -29,7 +29,7 @@ static void test(const char *model)
 	knet_handle_t knet_h[TESTNODES + 1];
 	int logfds[2];
 	struct knet_handle_crypto_cfg knet_handle_crypto_cfg;
-	int i,x,j;
+	int i,x;
 	int seconds = 10;
 
 	if (is_memcheck() || is_helgrind()) {
@@ -115,23 +115,8 @@ static void test(const char *model)
 			close_logpipes(logfds);
 			exit(FAIL);
 		}
-		for (x = 0; x < seconds; x++){
-			flush_logs(logfds[0], stdout);
-			sleep(1);
-		}
 		for (x = 1; x <= TESTNODES; x++) {
-			for (j = 1; j <= TESTNODES; j++) {
-				if (j == x) {
-					continue;
-				}
-				if (knet_h[x]->host_index[j]->status.reachable != 1) {
-					printf("knet failed to switch config for host %d\n", x);
-					knet_handle_stop_nodes(knet_h, TESTNODES);
-					flush_logs(logfds[0], stdout);
-					close_logpipes(logfds);
-					exit(FAIL);
-				}
-			}
+			wait_for_nodes_state(knet_h[x], TESTNODES, 1, 600, knet_h[1]->logfd, stdout);
 		}
 	}
 
@@ -147,24 +132,7 @@ static void test(const char *model)
 			close_logpipes(logfds);
 			exit(FAIL);
 		}
-		for (x = 0; x < seconds; x++){
-			flush_logs(logfds[0], stdout);
-			sleep(1);
-		}
-		for (x = 1; x <= TESTNODES; x++) {
-			for (j = 1; j <= TESTNODES; j++) {
-				if (j == x) {
-					continue;
-				}
-				if (knet_h[x]->host_index[j]->status.reachable != 1) {
-					printf("knet failed to switch config for host %d\n", x);
-					knet_handle_stop_nodes(knet_h, TESTNODES);
-					flush_logs(logfds[0], stdout);
-					close_logpipes(logfds);
-					exit(FAIL);
-				}
-			}
-		}
+		wait_for_nodes_state(knet_h[i], TESTNODES, 1, 600, knet_h[1]->logfd, stdout);
 	}
 
 	printf("Testing disable crypto config and allow clear traffic\n");
@@ -232,18 +200,7 @@ static void test(const char *model)
 			sleep(1);
 		}
 		for (x = 1; x <= TESTNODES; x++) {
-			for (j = 1; j <= TESTNODES; j++) {
-				if (j == x) {
-					continue;
-				}
-				if (knet_h[x]->host_index[j]->status.reachable != 1) {
-					printf("knet failed to switch config for host %d\n", x);
-					knet_handle_stop_nodes(knet_h, TESTNODES);
-					flush_logs(logfds[0], stdout);
-					close_logpipes(logfds);
-					exit(FAIL);
-				}
-			}
+			wait_for_nodes_state(knet_h[x], TESTNODES, 1, 600, knet_h[1]->logfd, stdout);
 		}
 	}
 

--- a/libknet/tests/fun_onwire_upgrade.c
+++ b/libknet/tests/fun_onwire_upgrade.c
@@ -87,16 +87,7 @@ static void test(void)
 
 	for (i = 1; i <= TESTNODES; i++) {
 		for (j = 1; j <= TESTNODES; j++) {
-			if (j == i) {
-				continue;
-			}
-			if (knet_h[i]->host_index[j]->status.reachable != 1) {
-				knet_handle_stop_nodes(knet_h, TESTNODES);
-				flush_logs(logfds[0], stdout);
-				close_logpipes(logfds);
-				exit(FAIL);
-			}
-		flush_logs(logfds[0], stdout);
+			wait_for_nodes_state(knet_h[j], TESTNODES, 1, 600, knet_h[1]->logfd, stdout);
 		}
 	}
 
@@ -120,15 +111,7 @@ static void test(void)
 	for (i = 1; i <= TESTNODES; i++) {
 		printf("node %u, onwire: %u min: %u max: %u\n", i, knet_h[i]->onwire_ver, knet_h[i]->onwire_min_ver, knet_h[i]->onwire_max_ver);
 		for (j = 1; j <= TESTNODES; j++) {
-			if (j == i) {
-				continue;
-			}
-			if ((knet_h[i]->host_index[j]->status.reachable != 1) || (knet_h[i]->onwire_ver != knet_h[1]->onwire_max_ver)) {
-				knet_handle_stop_nodes(knet_h, TESTNODES);
-				flush_logs(logfds[0], stdout);
-				close_logpipes(logfds);
-				exit(FAIL);
-			}
+			wait_for_nodes_state(knet_h[j], TESTNODES, 1, 600, knet_h[1]->logfd, stdout);
 		}
 	}
 
@@ -156,15 +139,7 @@ static void test(void)
 	for (i = 1; i <= TESTNODES; i++) {
 		printf("node %u, onwire: %u min: %u max: %u\n", i, knet_h[i]->onwire_ver, knet_h[i]->onwire_min_ver, knet_h[i]->onwire_max_ver);
 		for (j = 1; j <= TESTNODES; j++) {
-			if (j == i) {
-				continue;
-			}
-			if ((knet_h[i]->host_index[j]->status.reachable != 1) || (knet_h[i]->onwire_ver == knet_h[1]->onwire_max_ver)) {
-				knet_handle_stop_nodes(knet_h, TESTNODES);
-				flush_logs(logfds[0], stdout);
-				close_logpipes(logfds);
-				exit(FAIL);
-			}
+			wait_for_nodes_state(knet_h[j], TESTNODES, 1, 600, knet_h[1]->logfd, stdout);
 		}
 	}
 

--- a/libknet/tests/fun_onwire_upgrade.c
+++ b/libknet/tests/fun_onwire_upgrade.c
@@ -25,18 +25,21 @@
 
 #define TESTNODES 3
 
-static int upgrade_onwire_max_ver(knet_handle_t knet_h, uint8_t min, uint8_t max, int seconds)
+static int upgrade_onwire_max_ver(knet_handle_t knet_h, uint8_t min, uint8_t max, int seconds, int logfd, FILE *std)
 {
 	if (knet_handle_disconnect_links(knet_h) < 0) {
 		return -1;
 	}
-	sleep(seconds);
+
+	wait_for_nodes_state(knet_h, 3, 0, seconds, logfd, std);
+
 	knet_h->onwire_min_ver = min;
 	knet_h->onwire_max_ver = max;
 	if (knet_handle_reconnect_links(knet_h) < 0) {
 		return -1;
 	}
-	sleep(seconds);
+	wait_for_nodes_state(knet_h, 3, 1, seconds, logfd, std);
+
 	return 0;
 }
 
@@ -100,7 +103,8 @@ static void test(void)
 	printf("Test normal onwire upgrade from %u to %u\n", knet_h[1]->onwire_ver, knet_h[1]->onwire_ver + 1);
 
 	for (i = 1; i <= TESTNODES; i++) {
-		if (upgrade_onwire_max_ver(knet_h[i], knet_h[1]->onwire_ver, knet_h[1]->onwire_ver + 1, seconds) < 0) {
+		if (upgrade_onwire_max_ver(knet_h[i], knet_h[1]->onwire_ver, knet_h[1]->onwire_ver + 1, seconds,
+					   logfds[0], stdout) < 0) {
 			knet_handle_stop_nodes(knet_h, TESTNODES);
 			flush_logs(logfds[0], stdout);
 			close_logpipes(logfds);
@@ -135,7 +139,8 @@ static void test(void)
 	printf("Test onwire upgrade from %u to %u (all but one node)\n", knet_h[1]->onwire_ver, knet_h[1]->onwire_ver + 1);
 
 	for (i = 1; i < TESTNODES; i++) {
-		if (upgrade_onwire_max_ver(knet_h[i], knet_h[i]->onwire_ver, knet_h[i]->onwire_ver + 1, seconds) < 0) {
+		if (upgrade_onwire_max_ver(knet_h[i], knet_h[i]->onwire_ver, knet_h[i]->onwire_ver + 1, seconds,
+					   logfds[0], stdout) < 0) {
 			knet_handle_stop_nodes(knet_h, TESTNODES);
 			flush_logs(logfds[0], stdout);
 			close_logpipes(logfds);
@@ -170,7 +175,8 @@ static void test(void)
 	printf("Test onwire upgrade from %u to %u (all but one node - phase 2, node should be kicked out and remaining nodes should upgrade)\n", knet_h[1]->onwire_max_ver, knet_h[1]->onwire_max_ver + 1);
 
 	for (i = 1; i < TESTNODES; i++) {
-		if (upgrade_onwire_max_ver(knet_h[i], knet_h[i]->onwire_max_ver, knet_h[i]->onwire_max_ver + 1, seconds) < 0) {
+		if (upgrade_onwire_max_ver(knet_h[i], knet_h[i]->onwire_max_ver, knet_h[i]->onwire_max_ver + 1, seconds,
+					   logfds[0], stdout) < 0) {
 			knet_handle_stop_nodes(knet_h, TESTNODES);
 			flush_logs(logfds[0], stdout);
 			close_logpipes(logfds);
@@ -234,7 +240,8 @@ static void test(void)
 	 */
 	printf("Testing node rejoining one version lower (cluster should reject the node)\n");
 
-	if (upgrade_onwire_max_ver(knet_h[TESTNODES], knet_h[1]->onwire_min_ver - 1, knet_h[1]->onwire_max_ver - 1, seconds) < 0) {
+	if (upgrade_onwire_max_ver(knet_h[TESTNODES], knet_h[1]->onwire_min_ver - 1, knet_h[1]->onwire_max_ver - 1, seconds,
+				   logfds[0], stdout) < 0) {
 		knet_handle_stop_nodes(knet_h, TESTNODES);
 		flush_logs(logfds[0], stdout);
 		close_logpipes(logfds);
@@ -294,7 +301,8 @@ static void test(void)
 
 	printf("Testing node rejoining with proper version (cluster should reform)\n");
 
-	if (upgrade_onwire_max_ver(knet_h[TESTNODES], knet_h[1]->onwire_min_ver, knet_h[1]->onwire_max_ver, seconds) < 0) {
+	if (upgrade_onwire_max_ver(knet_h[TESTNODES], knet_h[1]->onwire_min_ver, knet_h[1]->onwire_max_ver, seconds,
+				   logfds[0], stdout) < 0) {
 		knet_handle_stop_nodes(knet_h, TESTNODES);
 		flush_logs(logfds[0], stdout);
 		close_logpipes(logfds);

--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -600,28 +600,6 @@ void test_sleep(knet_handle_t knet_h, int seconds)
 	sleep(seconds);
 }
 
-int wait_for_host(knet_handle_t knet_h, uint16_t host_id, int seconds, int logfd, FILE *std)
-{
-	int i = 0;
-
-	if (is_memcheck() || is_helgrind()) {
-		printf("Test suite is running under valgrind, adjusting wait_for_host timeout\n");
-		seconds = seconds * 16;
-	}
-
-	while (i < seconds) {
-		flush_logs(logfd, std);
-		if (knet_h->host_index[host_id]->status.reachable == 1) {
-			printf("Waiting for host to settle\n");
-			test_sleep(knet_h, 1);
-			return 0;
-		}
-		printf("waiting host %u to be reachable for %d more seconds\n", host_id, seconds - i);
-		sleep(1);
-		i++;
-	}
-	return -1;
-}
 
 int wait_for_packet(knet_handle_t knet_h, int seconds, int datafd, int logfd, FILE *std)
 {
@@ -751,21 +729,141 @@ void knet_handle_join_nodes(knet_handle_t knet_h[], uint8_t numnodes, uint8_t nu
 	}
 
 	for (i = 1; i <= numnodes; i++) {
-		for (j = 1; j <= numnodes; j++) {
-			/*
-			 * don´t wait for self
-			 */
-			if (j == i) {
-				continue;
-			}
+		wait_for_nodes_state(knet_h[i], numnodes, 1, 600, knet_h[1]->logfd, stdout);
+	}
+	return;
+}
 
-			if (wait_for_host(knet_h[i], j, (10 * numnodes) , knet_h[i]->logfd, stdout) < 0) {
-					printf("Cannot connect node %u to node %u: %s\n", i, j, strerror(errno));
-					knet_handle_stop_nodes(knet_h, numnodes);
-					exit(FAIL);
-			}
+
+static int target=0;
+static pthread_mutex_t wait_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t wait_cond = PTHREAD_COND_INITIALIZER;
+
+static int count_nodes(knet_handle_t knet_h)
+{
+	int nodes = 0;
+	int i;
+
+	for (i=0; i< KNET_MAX_HOST; i++) {
+		if (knet_h->host_index[i] && knet_h->host_index[i]->status.reachable == 1) {
+			nodes++;
 		}
 	}
+	return nodes;
+}
 
-	return;
+static void nodes_notify_callback(void *private_data,
+				  knet_node_id_t host_id,
+				  uint8_t reachable, uint8_t remote, uint8_t external)
+{
+	knet_handle_t knet_h = (knet_handle_t) private_data;
+	int nodes;
+
+	nodes = count_nodes(knet_h);
+
+	if (nodes == target) {
+		pthread_cond_signal(&wait_cond);
+	}
+}
+
+static void host_notify_callback(void *private_data,
+				 knet_node_id_t host_id,
+				 uint8_t reachable, uint8_t remote, uint8_t external)
+{
+	knet_handle_t knet_h = (knet_handle_t) private_data;
+
+	if (knet_h->host_index[host_id]->status.reachable == 1) {
+		pthread_cond_signal(&wait_cond);
+	}
+}
+
+/* Wait for a cluster of 'numnodes' to come up/go down */
+int wait_for_nodes_state(knet_handle_t knet_h, size_t numnodes,
+			 uint8_t state, uint32_t timeout,
+			 int logfd, FILE *std)
+{
+	struct timespec ts;
+	int res;
+
+	if (state) {
+		target = numnodes-1; /* exclude us */
+	} else {
+		target = 0; /* Wait for all to go down */
+	}
+
+	/* Set this before checking existing status or there's a race condition */
+	knet_host_enable_status_change_notify(knet_h,
+					      (void *)(long)knet_h,
+					      nodes_notify_callback);
+
+	/* Check we haven't already got all the nodes in the correct state */
+	if (count_nodes(knet_h) == target) {
+		fprintf(stderr, "target already reached\n");
+		knet_host_enable_status_change_notify(knet_h, (void *)(long)0, NULL);
+		flush_logs(logfd, std);
+		return 0;
+	}
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+	ts.tv_sec += timeout;
+	if (pthread_mutex_lock(&wait_mutex)) {
+		fprintf(stderr, "unable to get nodewait mutex: %s\n", strerror(errno));
+		return -1;
+	}
+	res = pthread_cond_timedwait(&wait_cond, &wait_mutex, &ts);
+	if (res == -1 && errno == ETIMEDOUT) {
+		fprintf(stderr, "Timed-out\n");
+	}
+	pthread_mutex_unlock(&wait_mutex);
+
+	knet_host_enable_status_change_notify(knet_h, (void *)(long)0, NULL);
+	flush_logs(logfd, std);
+	return res;
+}
+
+/* Wait for a single node to come up */
+int wait_for_host(knet_handle_t knet_h, uint16_t host_id, int seconds, int logfd, FILE *std)
+{
+	int res;
+	struct timespec ts;
+
+	if (is_memcheck() || is_helgrind()) {
+		printf("Test suite is running under valgrind, adjusting wait_for_host timeout\n");
+		seconds = seconds * 16;
+	}
+
+	/* Set this before checking existing status or there's a race condition */
+	knet_host_enable_status_change_notify(knet_h,
+					      (void *)(long)knet_h,
+					      host_notify_callback);
+
+	/* Check it's not already reachable */
+	if (knet_h->host_index[host_id]->status.reachable == 1) {
+		knet_host_enable_status_change_notify(knet_h, (void *)(long)0, NULL);
+		flush_logs(logfd, std);
+		return 0;
+	}
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+	ts.tv_sec += seconds;
+	if (pthread_mutex_lock(&wait_mutex)) {
+		fprintf(stderr, "unable to get nodewait mutex: %s\n", strerror(errno));
+		return -1;
+	}
+	res = pthread_cond_timedwait(&wait_cond, &wait_mutex, &ts);
+	if (res == -1 && errno == ETIMEDOUT) {
+		fprintf(stderr, "Timed-out\n");
+		knet_host_enable_status_change_notify(knet_h, (void *)(long)0, NULL);
+		pthread_mutex_unlock(&wait_mutex);
+		flush_logs(logfd, std);
+		return -1;
+	}
+	pthread_mutex_unlock(&wait_mutex);
+
+	knet_host_enable_status_change_notify(knet_h, (void *)(long)0, NULL);
+
+	/* Still wait for it to settle */
+	flush_logs(logfd, std);
+	test_sleep(knet_h, 1);
+	return 0;
 }

--- a/libknet/tests/test-common.h
+++ b/libknet/tests/test-common.h
@@ -89,5 +89,8 @@ int make_local_sockaddr6(struct sockaddr_storage *lo, int offset);
 int wait_for_host(knet_handle_t knet_h, uint16_t host_id, int seconds, int logfd, FILE *std);
 int wait_for_packet(knet_handle_t knet_h, int seconds, int datafd, int logfd, FILE *std);
 void test_sleep(knet_handle_t knet_h, int seconds);
+int wait_for_nodes_state(knet_handle_t knet_h, size_t numnodes,
+			 uint8_t state, uint32_t timeout,
+			 int logfd, FILE *std);
 
 #endif


### PR DESCRIPTION
Rather than just wait for a arbitrary amount of time for
nodes to come online while testing, use the knet callback
mechanism. This should not only save some time in the running
of the tests, but also make them less susceptible to slowness
on the CI machines.

First pass to check it does actually work on all the CI nodes!