### PR TITLE
[handle] validate handle in public API

### DIFF
--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -31,6 +31,7 @@ sources			= \
 			  handle.c \
 			  handle_api.c \
 			  host.c \
+			  lib_config.c \
 			  links.c \
 			  links_acl.c \
 			  links_acl_ip.c \

--- a/libknet/compress.c
+++ b/libknet/compress.c
@@ -490,8 +490,7 @@ int knet_handle_compress(knet_handle_t knet_h, struct knet_handle_compress_cfg *
 	int savederrno = 0;
 	int err = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/crypto.c
+++ b/libknet/crypto.c
@@ -299,8 +299,7 @@ int knet_handle_crypto_set_config(knet_handle_t knet_h,
 	int savederrno = 0;
 	int err = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -371,8 +370,7 @@ int knet_handle_crypto_rx_clear_traffic(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -406,8 +404,7 @@ int knet_handle_crypto_use_config(knet_handle_t knet_h,
 	int savederrno = 0;
 	int err = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/handle_api.c
+++ b/libknet/handle_api.c
@@ -35,8 +35,7 @@ int knet_handle_enable_sock_notify(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -68,8 +67,7 @@ int knet_handle_add_datafd(knet_handle_t knet_h, int *datafd, int8_t *channel)
 	int i;
 	struct epoll_event ev;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -210,8 +208,7 @@ int knet_handle_remove_datafd(knet_handle_t knet_h, int datafd)
 	int i;
 	struct epoll_event ev;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -271,8 +268,7 @@ int knet_handle_get_datafd(knet_handle_t knet_h, const int8_t channel, int *data
 {
 	int err = 0, savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -313,8 +309,7 @@ int knet_handle_get_channel(knet_handle_t knet_h, const int datafd, int8_t *chan
 	int err = 0, savederrno = 0;
 	int i;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -373,8 +368,7 @@ int knet_handle_enable_filter(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -404,8 +398,7 @@ int knet_handle_setfwd(knet_handle_t knet_h, unsigned int enabled)
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -481,8 +474,7 @@ int knet_handle_get_stats(knet_handle_t knet_h, struct knet_handle_stats *stats,
 {
 	int err = 0, savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -536,8 +528,7 @@ int knet_handle_clear_stats(knet_handle_t knet_h, int clear_option)
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -569,8 +560,7 @@ int knet_handle_enable_access_lists(knet_handle_t knet_h, unsigned int enabled)
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/host.c
+++ b/libknet/host.c
@@ -37,8 +37,7 @@ int knet_host_add(knet_handle_t knet_h, knet_node_id_t host_id)
 	struct knet_host *host = NULL;
 	uint8_t link_idx;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -126,8 +125,7 @@ int knet_host_remove(knet_handle_t knet_h, knet_node_id_t host_id)
 	struct knet_host *host, *removed;
 	uint8_t link_idx;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -197,8 +195,7 @@ int knet_host_set_name(knet_handle_t knet_h, knet_node_id_t host_id, const char 
 	int savederrno = 0, err = 0;
 	struct knet_host *host;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -257,8 +254,7 @@ int knet_host_get_name_by_host_id(knet_handle_t knet_h, knet_node_id_t host_id,
 {
 	int savederrno = 0, err = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -296,8 +292,7 @@ int knet_host_get_id_by_host_name(knet_handle_t knet_h, const char *name,
 	int savederrno = 0, err = 0, found = 0;
 	struct knet_host *host;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -342,8 +337,7 @@ int knet_host_get_host_list(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -373,8 +367,7 @@ int knet_host_set_policy(knet_handle_t knet_h, knet_node_id_t host_id,
 	int savederrno = 0, err = 0;
 	uint8_t old_policy;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -423,8 +416,7 @@ int knet_host_get_policy(knet_handle_t knet_h, knet_node_id_t host_id,
 {
 	int savederrno = 0, err = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -463,8 +455,7 @@ int knet_host_get_status(knet_handle_t knet_h, knet_node_id_t host_id,
 	int savederrno = 0, err = 0;
 	struct knet_host *host;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -509,8 +500,7 @@ int knet_host_enable_status_change_notify(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -293,9 +293,24 @@ struct knet_handle {
 		uint8_t onwire_ver);
 	int fini_in_progress;
 	uint64_t flags;
+	struct qb_list_head list;
 };
 
+struct handle_tracker {
+	struct qb_list_head head;
+};
+
+/*
+ * lib_config stuff shared across everything
+ */
 extern pthread_rwlock_t shlib_rwlock;       /* global shared lib load lock */
+extern pthread_mutex_t handle_config_mutex;
+
+extern struct handle_tracker handle_list;
+extern uint8_t handle_list_init;
+int _is_valid_handle(knet_handle_t knet_h);
+int _init_shlib_tracker(knet_handle_t knet_h);
+void _fini_shlib_tracker(void);
 
 /*
  * NOTE: every single operation must be implementend

--- a/libknet/lib_config.c
+++ b/libknet/lib_config.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
+ *
+ * This software licensed under LGPL-2.0+
+ */
+
+#include "config.h"
+
+#include <pthread.h>
+#include <string.h>
+#include <errno.h>
+
+#include "internals.h"
+#include "logging.h"
+
+pthread_mutex_t handle_config_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+struct handle_tracker handle_list;
+uint8_t handle_list_init = 0;
+
+int _is_valid_handle(knet_handle_t knet_h)
+{
+	int found = 0;
+	int savederrno = 0;
+	knet_handle_t temp = NULL;
+
+	/*
+	 * we are validating the handle, hence we cannot use
+	 * the handle for logging purposes
+	 */
+	savederrno = pthread_mutex_lock(&handle_config_mutex);
+	if (savederrno) {
+		errno = savederrno;
+		return 0;
+	}
+
+	errno = EINVAL;
+	/*
+	 * this is to protect against knet_handle_free being called
+	 * before knet_handle_new that initialize the list struct
+	 */
+	if (handle_list_init) {
+		qb_list_for_each_entry(temp, &handle_list.head, list) {
+			if (temp == knet_h) {
+				found = 1;
+				errno = 0;
+			}
+		}
+	}
+
+	pthread_mutex_unlock(&handle_config_mutex);
+
+	return found;
+}
+
+pthread_rwlock_t shlib_rwlock;
+static uint8_t shlib_wrlock_init = 0;
+
+int _init_shlib_tracker(knet_handle_t knet_h)
+{
+	int savederrno = 0;
+
+	if (!shlib_wrlock_init) {
+		savederrno = pthread_rwlock_init(&shlib_rwlock, NULL);
+		if (savederrno) {
+			log_err(knet_h, KNET_SUB_HANDLE, "Unable to initialize shared lib rwlock: %s",
+				strerror(savederrno));
+			errno = savederrno;
+			return -1;
+		}
+		shlib_wrlock_init = 1;
+	}
+
+	return 0;
+}
+
+void _fini_shlib_tracker(void)
+{
+	if (qb_list_empty(&handle_list.head)) {
+		pthread_rwlock_destroy(&shlib_rwlock);
+		shlib_wrlock_init = 0;
+	}
+	return;
+}

--- a/libknet/links.c
+++ b/libknet/links.c
@@ -124,8 +124,7 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -357,8 +356,7 @@ int knet_link_get_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -446,8 +444,7 @@ int knet_link_clear_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t
 	int sock;
 	uint8_t transport;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -561,8 +558,7 @@ int knet_link_set_enable(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -631,8 +627,7 @@ int knet_link_get_enable(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -688,8 +683,7 @@ int knet_link_set_pong_count(knet_handle_t knet_h, knet_node_id_t host_id, uint8
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -749,8 +743,7 @@ int knet_link_get_pong_count(knet_handle_t knet_h, knet_node_id_t host_id, uint8
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -806,8 +799,7 @@ int knet_link_set_ping_timers(knet_handle_t knet_h, knet_node_id_t host_id, uint
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -879,8 +871,7 @@ int knet_link_get_ping_timers(knet_handle_t knet_h, knet_node_id_t host_id, uint
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -949,8 +940,7 @@ int knet_link_set_priority(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t
 	struct knet_link *link;
 	uint8_t old_priority;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1022,8 +1012,7 @@ int knet_link_get_priority(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1079,8 +1068,7 @@ int knet_link_get_link_list(knet_handle_t knet_h, knet_node_id_t host_id,
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1135,8 +1123,7 @@ int knet_link_get_status(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1242,8 +1229,7 @@ int knet_link_enable_status_change_notify(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1278,8 +1264,7 @@ int knet_link_add_acl(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t link
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1373,8 +1358,7 @@ int knet_link_insert_acl(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1467,8 +1451,7 @@ int knet_link_rm_acl(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t link_
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -1558,8 +1541,7 @@ int knet_link_clear_acl(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t li
 	struct knet_host *host;
 	struct knet_link *link;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/logging.c
+++ b/libknet/logging.c
@@ -139,8 +139,7 @@ int knet_log_set_loglevel(knet_handle_t knet_h, uint8_t subsystem,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -174,8 +173,7 @@ int knet_log_get_loglevel(knet_handle_t knet_h, uint8_t subsystem,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/onwire.c
+++ b/libknet/onwire.c
@@ -136,8 +136,7 @@ int knet_handle_enable_onwire_ver_notify(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -179,8 +178,7 @@ int knet_handle_get_onwire_ver(knet_handle_t knet_h,
 	int err = 0, savederrno = 0;
 	struct knet_host *host;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -240,8 +238,7 @@ int knet_handle_set_onwire_ver(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/tests/Makefile.am
+++ b/libknet/tests/Makefile.am
@@ -88,7 +88,8 @@ int_links_acl_ip_test_SOURCES = int_links_acl_ip.c \
 				../transport_udp.c \
 				../links_acl.c \
 				../links_acl_ip.c \
-				../links_acl_loopback.c
+				../links_acl_loopback.c \
+				../lib_config.c
 
 int_timediff_test_SOURCES = int_timediff.c
 
@@ -99,13 +100,15 @@ knet_bench_test_SOURCES	= knet_bench.c \
 			  ../compat.c \
 			  ../transport_common.c \
 			  ../threads_common.c \
-			  ../onwire.c
+			  ../onwire.c \
+			  ../lib_config.c
 
 fun_pmtud_crypto_test_SOURCES = fun_pmtud_crypto.c \
 				test-common.c \
 				../onwire.c \
 				../logging.c \
-				../threads_common.c
+				../threads_common.c \
+				../lib_config.c
 
 fun_config_crypto_test_SOURCES = fun_config_crypto.c \
 				 test-common.c

--- a/libknet/tests/api_knet_handle_free.c
+++ b/libknet/tests/api_knet_handle_free.c
@@ -26,7 +26,7 @@ static void test(void)
 
 	setup_logpipes(logfds);
 
-	printf("Test knet_handle_free with invalid knet_h\n");
+	printf("Test knet_handle_free with invalid knet_h (part 1)\n");
 
 	if ((!knet_handle_free(NULL)) || (errno != EINVAL)) {
 		printf("knet_handle_free failed to detect invalid parameter\n");
@@ -57,6 +57,15 @@ static void test(void)
 	if (knet_host_remove(knet_h, 1) < 0) {
 		printf("Unable to remove knet_host: %s\n", strerror(errno));
 		knet_handle_free(knet_h);
+		flush_logs(logfds[0], stdout);
+		close_logpipes(logfds);
+		exit(FAIL);
+	}
+
+	printf("Test knet_handle_free with invalid knet_h (part 2)\n");
+
+	if ((!knet_handle_free(knet_h + 1)) || (errno != EINVAL)) {
+		printf("knet_handle_free failed to detect invalid parameter\n");
 		flush_logs(logfds[0], stdout);
 		close_logpipes(logfds);
 		exit(FAIL);

--- a/libknet/threads_common.c
+++ b/libknet/threads_common.c
@@ -253,8 +253,7 @@ int knet_handle_set_threads_timer_res(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -293,8 +292,7 @@ int knet_handle_get_threads_timer_res(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -782,8 +782,7 @@ int knet_handle_pmtud_getfreq(knet_handle_t knet_h, unsigned int *interval)
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -812,8 +811,7 @@ int knet_handle_pmtud_setfreq(knet_handle_t knet_h, unsigned int interval)
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -847,8 +845,7 @@ int knet_handle_enable_pmtud_notify(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -879,8 +876,7 @@ int knet_handle_pmtud_set(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -914,8 +910,7 @@ int knet_handle_pmtud_get(knet_handle_t knet_h,
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -899,8 +899,7 @@ ssize_t knet_recv(knet_handle_t knet_h, char *buff, const size_t buff_len, const
 	ssize_t err = 0;
 	struct iovec iov_in;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -836,8 +836,7 @@ int knet_send_sync(knet_handle_t knet_h, const char *buff, const size_t buff_len
 	int savederrno = 0, err = 0;
 	uint8_t onwire_ver;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -927,8 +926,7 @@ ssize_t knet_send(knet_handle_t knet_h, const char *buff, const size_t buff_len,
 	ssize_t err = 0;
 	struct iovec iov_out[1];
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 

--- a/libknet/transports.c
+++ b/libknet/transports.c
@@ -234,8 +234,7 @@ int knet_handle_set_transport_reconnect_interval(knet_handle_t knet_h, uint32_t 
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 
@@ -271,8 +270,7 @@ int knet_handle_get_transport_reconnect_interval(knet_handle_t knet_h, uint32_t 
 {
 	int savederrno = 0;
 
-	if (!knet_h) {
-		errno = EINVAL;
+	if (!_is_valid_handle(knet_h)) {
 		return -1;
 	}
 


### PR DESCRIPTION
- add _is_valid_handle() function to verify if a handle
  is known, via qb_list*

- change all (and only) public API to use _is_valid_handle().

- move library config bits to lib_config.c and keep
  header bit in internal.h.
  this is more of a commodity need to simplify
  accessability of above function to the test suite
  at link time.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>