### PR TITLE
[nozzle] Remove inet_ntoa() call

### DIFF
--- a/libnozzle/internals.c
+++ b/libnozzle/internals.c
@@ -141,6 +141,7 @@ char *generate_v4_broadcast(const char *ipaddr, const char *prefix)
 	struct in_addr mask;
 	struct in_addr broadcast;
 	struct in_addr address;
+	char buf[INET6_ADDRSTRLEN];
 
 	prefix_len = atoi(prefix);
 
@@ -155,7 +156,7 @@ char *generate_v4_broadcast(const char *ipaddr, const char *prefix)
 	memset(&broadcast, 0, sizeof(broadcast));
 	broadcast.s_addr = (address.s_addr & mask.s_addr) | ~mask.s_addr;
 
-	return strdup(inet_ntoa(broadcast));
+	return strdup(inet_ntop(AF_INET, (void *)&broadcast, buf, sizeof(buf)));
 }
 
 int find_ip(nozzle_t nozzle,


### PR DESCRIPTION
inet_ntoa() is deprecated in favour of inet_ntop() (see man page for
inet_ntop()).