### PR TITLE
[lib] Don't use -rpath

### DIFF
--- a/libknet/Makefile.am
+++ b/libknet/Makefile.am
@@ -93,13 +93,13 @@ libknet_la_SOURCES	= $(sources)
 
 AM_CFLAGS		+= $(libqb_CFLAGS)
 
-libknet_la_CFLAGS	= $(AM_CFLAGS) $(PTHREAD_CFLAGS)
+libknet_la_CFLAGS	= $(AM_CFLAGS) $(PTHREAD_CFLAGS) \
+			  -DPLUGINPATH="\"$(pkglibdir)\""
 
 EXTRA_libknet_la_DEPENDENCIES	= $(SYMFILE)
 
 libknet_la_LDFLAGS	= $(AM_LDFLAGS) \
 			  -Wl,--version-script=$(srcdir)/$(SYMFILE) \
-			  -Wl,-rpath=$(pkglibdir) \
 			  -version-info $(libversion)
 
 libknet_la_LIBADD	= $(PTHREAD_LIBS) $(dl_LIBS) $(rt_LIBS) $(m_LIBS)

--- a/libknet/common.c
+++ b/libknet/common.c
@@ -91,8 +91,11 @@ static void *open_lib(knet_handle_t knet_h, const char *libname, int extra_flags
 	 * clear any pending error
 	 */
 	dlerror();
+	strncpy(path, knet_h->plugin_path, sizeof(path)-1);
+	strncat(path, "/", sizeof(path)-1);
+	strncat(path, libname, sizeof(path)-strlen(knet_h->plugin_path)-2);
 
-	ret = dlopen(libname, RTLD_NOW | RTLD_GLOBAL | extra_flags);
+	ret = dlopen(path, RTLD_NOW | RTLD_GLOBAL | extra_flags);
 	if (!ret) {
 		error = dlerror();
 		if (error) {

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -603,6 +603,11 @@ knet_handle_t knet_handle_new(knet_node_id_t host_id,
 	knet_h->reconnect_int = KNET_TRANSPORT_DEFAULT_RECONNECT_INTERVAL;
 
 	/*
+	 * Set the default path for plugins
+	 */
+	knet_h->plugin_path = PLUGINPATH;
+
+	/*
 	 * Set 'min' stats to the maximum value so the
 	 * first value we get is always less
 	 */

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -294,6 +294,7 @@ struct knet_handle {
 	int fini_in_progress;
 	uint64_t flags;
 	struct qb_list_head list;
+	const char *plugin_path;
 };
 
 struct handle_tracker {


### PR DESCRIPTION
rpath seems to annoy some analysis tools. We
use it to locate the crypto & compression plugins but libknet also needs
to use the plugins from the build-tree when running tests.

A simple way to do this is have the plugin directory as part of the knet
handle then we can override it in the test suite, which already does
'illegal' accesses to some handle fields.

OK, it's not the MOST elegant way of doing this perhaps, but it is
simple and effective.