### PR TITLE
send 'correct' sockaddr lengths to socket calls

### DIFF
--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -152,6 +152,7 @@ struct knet_fd_trackers {
 	uint8_t transport;		    /* transport type (UDP/SCTP...) */
 	uint8_t data_type;		    /* internal use for transport to define what data are associated
 					     * with this fd */
+	socklen_t sockaddr_len;             /* Size of sockaddr_in[6] structure for this socket */
 	void *data;			    /* pointer to the data */
 	void *access_list_match_entry_head; /* pointer to access list match_entry list head */
 };

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -117,7 +117,8 @@ static void send_ping(knet_handle_t knet_h, struct knet_host *dst_host, struct k
 retry:
 		if (transport_get_connection_oriented(knet_h, dst_link->transport) == TRANSPORT_PROTO_NOT_CONNECTION_ORIENTED) {
 			len = sendto(dst_link->outsock, outbuf, outlen,	MSG_DONTWAIT | MSG_NOSIGNAL,
-				     (struct sockaddr *) &dst_link->dst_addr, sizeof(struct sockaddr_storage));
+				     (struct sockaddr *) &dst_link->dst_addr,
+				     knet_h->knet_transport_fd_tracker[dst_link->outsock].sockaddr_len);
 		} else {
 			len = sendto(dst_link->outsock, outbuf, outlen,	MSG_DONTWAIT | MSG_NOSIGNAL, NULL, 0);
 		}
@@ -201,7 +202,8 @@ retry:
 	if (src_link->transport_connected) {
 		if (transport_get_connection_oriented(knet_h, src_link->transport) == TRANSPORT_PROTO_NOT_CONNECTION_ORIENTED) {
 			len = sendto(src_link->outsock, outbuf, outlen, MSG_DONTWAIT | MSG_NOSIGNAL,
-				     (struct sockaddr *) &src_link->dst_addr, sizeof(struct sockaddr_storage));
+				     (struct sockaddr *) &src_link->dst_addr,
+				     knet_h->knet_transport_fd_tracker[src_link->outsock].sockaddr_len);
 		} else {
 			len = sendto(src_link->outsock, outbuf, outlen, MSG_DONTWAIT | MSG_NOSIGNAL, NULL, 0);
 		}

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -224,7 +224,8 @@ restart:
 retry:
 	if (transport_get_connection_oriented(knet_h, dst_link->transport) == TRANSPORT_PROTO_NOT_CONNECTION_ORIENTED) {
 		len = sendto(dst_link->outsock, outbuf, data_len, MSG_DONTWAIT | MSG_NOSIGNAL,
-			     (struct sockaddr *) &dst_link->dst_addr, sizeof(struct sockaddr_storage));
+			     (struct sockaddr *) &dst_link->dst_addr,
+			     knet_h->knet_transport_fd_tracker[dst_link->outsock].sockaddr_len);
 	} else {
 		len = sendto(dst_link->outsock, outbuf, data_len, MSG_DONTWAIT | MSG_NOSIGNAL, NULL, 0);
 	}
@@ -705,7 +706,8 @@ retry:
 	if (src_link->transport_connected) {
 		if (transport_get_connection_oriented(knet_h, src_link->transport) == TRANSPORT_PROTO_NOT_CONNECTION_ORIENTED) {
 			len = sendto(src_link->outsock, outbuf, outlen, MSG_DONTWAIT | MSG_NOSIGNAL,
-				     (struct sockaddr *) &src_link->dst_addr, sizeof(struct sockaddr_storage));
+				     (struct sockaddr *) &src_link->dst_addr,
+				     knet_h->knet_transport_fd_tracker[src_link->outsock].sockaddr_len);
 		} else {
 			len = sendto(src_link->outsock, outbuf, outlen, MSG_DONTWAIT | MSG_NOSIGNAL, NULL, 0);
 		}

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -741,7 +741,7 @@ static void _handle_recv_from_links(knet_handle_t knet_h, int sockfd, struct kne
 	 */
 
 	for (i = 0; i < PCKT_RX_BUFS; i++) {
-		msg[i].msg_hdr.msg_namelen = sizeof(struct sockaddr_storage);
+		msg[i].msg_hdr.msg_namelen = knet_h->knet_transport_fd_tracker[sockfd].sockaddr_len;
 	}
 
 	msg_recv = _recvmmsg(sockfd, &msg[0], PCKT_RX_BUFS, MSG_DONTWAIT | MSG_NOSIGNAL);
@@ -859,7 +859,7 @@ void *_handle_recv_from_links_thread(void *data)
 		memset(&msg[i].msg_hdr, 0, sizeof(struct msghdr));
 
 		msg[i].msg_hdr.msg_name = &address[i];
-		msg[i].msg_hdr.msg_namelen = sizeof(struct sockaddr_storage);
+		msg[i].msg_hdr.msg_namelen = sizeof(struct sockaddr_storage); /* Real value filled in before actual use */
 		msg[i].msg_hdr.msg_iov = &iov_in[i];
 		msg[i].msg_hdr.msg_iovlen = 1;
 	}

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -63,6 +63,7 @@ static int _dispatch_to_links(knet_handle_t knet_h, struct knet_host *dst_host, 
 		msg_idx = 0;
 		while (msg_idx < msgs_to_send) {
 			msg[msg_idx].msg_hdr.msg_name = &cur_link->dst_addr;
+			msg[msg_idx].msg_hdr.msg_namelen = knet_h->knet_transport_fd_tracker[cur_link->outsock].sockaddr_len;
 
 			/* Cast for Linux/BSD compatibility */
 			for (i=0; i<(unsigned int)msg[msg_idx].msg_hdr.msg_iovlen; i++) {
@@ -536,7 +537,7 @@ static int _prep_and_send_msgs(knet_handle_t knet_h, int bcast, knet_node_id_t *
 	msg_idx = 0;
 
 	while (msg_idx < msgs_to_send) {
-		msg[msg_idx].msg_hdr.msg_namelen = sizeof(struct sockaddr_storage);
+		msg[msg_idx].msg_hdr.msg_namelen = sockaddr_len((const struct sockaddr_storage *)&msg[msg_idx].msg_hdr.msg_name);
 		msg[msg_idx].msg_hdr.msg_iov = &iov_out[msg_idx][0];
 		msg[msg_idx].msg_hdr.msg_iovlen = iovcnt_out;
 		msg_idx++;
@@ -689,7 +690,7 @@ static void _handle_send_to_links(knet_handle_t knet_h, int sockfd, uint8_t onwi
 
 	memset(&msg, 0, sizeof(struct msghdr));
 	msg.msg_name = &address;
-	msg.msg_namelen = sizeof(struct sockaddr_storage);
+	msg.msg_namelen = knet_h->knet_transport_fd_tracker[sockfd].sockaddr_len;
 	msg.msg_iov = &iov_in;
 	msg.msg_iovlen = 1;
 

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -426,7 +426,7 @@ int _is_valid_fd(knet_handle_t knet_h, int sockfd)
  * must be called with global write lock
  */
 
-int _set_fd_tracker(knet_handle_t knet_h, int sockfd, uint8_t transport, uint8_t data_type, void *data)
+int _set_fd_tracker(knet_handle_t knet_h, int sockfd, uint8_t transport, uint8_t data_type, socklen_t socklen, void *data)
 {
 	if (sockfd < 0) {
 		errno = EINVAL;
@@ -440,6 +440,7 @@ int _set_fd_tracker(knet_handle_t knet_h, int sockfd, uint8_t transport, uint8_t
 
 	knet_h->knet_transport_fd_tracker[sockfd].transport = transport;
 	knet_h->knet_transport_fd_tracker[sockfd].data_type = data_type;
+	knet_h->knet_transport_fd_tracker[sockfd].sockaddr_len = socklen;
 	knet_h->knet_transport_fd_tracker[sockfd].data = data;
 
 	return 0;

--- a/libknet/transport_common.h
+++ b/libknet/transport_common.h
@@ -15,7 +15,7 @@ int _configure_transport_socket(knet_handle_t knet_h, int sock, struct sockaddr_
 int _init_socketpair(knet_handle_t knet_h, int *sock);
 void _close_socketpair(knet_handle_t knet_h, int *sock);
 
-int _set_fd_tracker(knet_handle_t knet_h, int sockfd, uint8_t transport, uint8_t data_type, void *data);
+int _set_fd_tracker(knet_handle_t knet_h, int sockfd, uint8_t transport, uint8_t data_type, socklen_t socklen, void *data);
 int _is_valid_fd(knet_handle_t knet_h, int sockfd);
 
 int _sendmmsg(int sockfd, int connection_oriented, struct knet_mmsghdr *msgvec, unsigned int vlen, unsigned int flags);

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -118,7 +118,7 @@ static int _close_connect_socket(knet_handle_t knet_h, struct knet_link *kn_link
 			info->on_rx_epoll = 0;
 		}
 
-		if (_set_fd_tracker(knet_h, info->connect_sock, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, NULL) < 0) {
+		if (_set_fd_tracker(knet_h, info->connect_sock, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, 0, NULL) < 0) {
 			savederrno = errno;
 			err = -1;
 			log_err(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to set fd tracker: %s",
@@ -258,7 +258,7 @@ static int _create_connect_socket(knet_handle_t knet_h, struct knet_link *kn_lin
 		goto exit_error;
 	}
 
-	if (_set_fd_tracker(knet_h, connect_sock, KNET_TRANSPORT_SCTP, SCTP_CONNECT_LINK_INFO, info) < 0) {
+	if (_set_fd_tracker(knet_h, connect_sock, KNET_TRANSPORT_SCTP, SCTP_CONNECT_LINK_INFO, sockaddr_len(&kn_link->src_addr), info) < 0) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to set fd tracker: %s",
@@ -845,7 +845,9 @@ static void _handle_incoming_sctp(knet_handle_t knet_h, int listen_sock)
 
 	accept_info->link_info = info;
 
-	if (_set_fd_tracker(knet_h, new_fd, KNET_TRANSPORT_SCTP, SCTP_ACCEPTED_LINK_INFO, accept_info) < 0) {
+	if (_set_fd_tracker(knet_h, new_fd, KNET_TRANSPORT_SCTP, SCTP_ACCEPTED_LINK_INFO,
+			    knet_h->knet_transport_fd_tracker[listen_sock].sockaddr_len,
+			    accept_info) < 0) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to set fd tracker: %s",
@@ -877,7 +879,7 @@ exit_error:
 		 * check the error to make coverity scan happy.
 		 * _set_fd_tracker cannot fail at this stage
 		 */
-		if (_set_fd_tracker(knet_h, new_fd, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, NULL) < 0){
+		if (_set_fd_tracker(knet_h, new_fd, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, 0, NULL) < 0){
 			log_debug(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to update fdtracker for socket %d", new_fd);
 		}
 		free(accept_info);
@@ -951,7 +953,7 @@ static void _handle_listen_sctp_errors(knet_handle_t knet_h)
 			 * check the error to make coverity scan happy.
 			 * _set_fd_tracker cannot fail at this stage
 			 */
-			if (_set_fd_tracker(knet_h, sockfd, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, NULL) < 0) {
+			if (_set_fd_tracker(knet_h, sockfd, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, 0, NULL) < 0) {
 				log_debug(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to update fdtracker for socket %d", sockfd);
 			}
 			info->accepted_socks[i] = -1;
@@ -1087,7 +1089,7 @@ static sctp_listen_link_info_t *sctp_link_listener_start(knet_handle_t knet_h, s
 		goto exit_error;
 	}
 
-	if (_set_fd_tracker(knet_h, listen_sock, KNET_TRANSPORT_SCTP, SCTP_LISTENER_LINK_INFO, info) < 0) {
+	if (_set_fd_tracker(knet_h, listen_sock, KNET_TRANSPORT_SCTP, SCTP_LISTENER_LINK_INFO, sockaddr_len(&kn_link->src_addr), info) < 0) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to set fd tracker: %s",
@@ -1192,7 +1194,7 @@ static int sctp_link_listener_stop(knet_handle_t knet_h, struct knet_link *kn_li
 		info->on_listener_epoll = 0;
 	}
 
-	if (_set_fd_tracker(knet_h, info->listen_sock, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, NULL) < 0) {
+	if (_set_fd_tracker(knet_h, info->listen_sock, KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, 0, NULL) < 0) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to set fd tracker: %s",
@@ -1216,7 +1218,7 @@ static int sctp_link_listener_stop(knet_handle_t knet_h, struct knet_link *kn_li
 			info->on_rx_epoll = 0;
 			free(knet_h->knet_transport_fd_tracker[info->accepted_socks[i]].data);
 			close(info->accepted_socks[i]);
-			if (_set_fd_tracker(knet_h, info->accepted_socks[i], KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, NULL) < 0) {
+			if (_set_fd_tracker(knet_h, info->accepted_socks[i], KNET_MAX_TRANSPORTS, SCTP_NO_LINK_INFO, 0, NULL) < 0) {
 				savederrno = errno;
 				err = -1;
 				log_err(knet_h, KNET_SUB_TRANSP_SCTP, "Unable to set fd tracker: %s",

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -143,7 +143,7 @@ int udp_transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_lin
 
 	info->on_epoll = 1;
 
-	if (_set_fd_tracker(knet_h, sock, KNET_TRANSPORT_UDP, 0, info) < 0) {
+	if (_set_fd_tracker(knet_h, sock, KNET_TRANSPORT_UDP, 0, sockaddr_len(&kn_link->src_addr), info) < 0) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSP_UDP, "Unable to set fd tracker: %s",
@@ -218,7 +218,7 @@ int udp_transport_link_clear_config(knet_handle_t knet_h, struct knet_link *kn_l
 		info->on_epoll = 0;
 	}
 
-	if (_set_fd_tracker(knet_h, info->socket_fd, KNET_MAX_TRANSPORTS, 0, NULL) < 0) {
+	if (_set_fd_tracker(knet_h, info->socket_fd, KNET_MAX_TRANSPORTS, 0, sockaddr_len(&kn_link->src_addr), NULL) < 0) {
 		savederrno = errno;
 		err = -1;
 		log_err(knet_h, KNET_SUB_TRANSP_UDP, "Unable to set fd tracker: %s",


### PR DESCRIPTION
FreeBSD-devel insists that the length passed into socket calls
matches the expected length of the sockaddr it describes.
So, eg, when passing a sockaddr_in, the length must be sizeof(sockaddr_in)
rather than sizeof(sockaddr_storage) which we were using

Signed-Off-By: Chrissie Caulfield <ccaulfie@redhat.com>