### PR TITLE
Require make utility

### DIFF
--- a/kronosnet.spec.in
+++ b/kronosnet.spec.in
@@ -49,7 +49,7 @@ URL: https://kronosnet.org
 Source0: https://kronosnet.org/releases/%{name}-%{version}%{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}.tar.gz
 
 # Build dependencies
-BuildRequires: gcc libqb-devel
+BuildRequires: gcc libqb-devel make
 # required to build man pages
 %if %{with buildman}
 BuildRequires: doxygen doxygen2man


### PR DESCRIPTION
kronosnet.spec.in does not require make, which results in:

...
config.status: executing depfiles commands
config.status: executing libtool commands
+ make -j64
/var/tmp/rpm-tmp.kYgeCw: line 80: make: command not found
error: Bad exit status from /var/tmp/rpm-tmp.kYgeCw (%build)


RPM build errors:
    kronosnet-1.18-1.el8.src.rpm: Header V3 RSA/SHA256 Signature, key ID 8483c65d: NOKEY

Hard to believe anyone would not have make installed, but it can happen!