### PR TITLE
Sanitise sockaddr_storage structs coming in the API

### DIFF
--- a/libknet/links.c
+++ b/libknet/links.c
@@ -210,7 +210,7 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 		goto exit_unlock;
 	}
 
-	memmove(&link->src_addr, src_addr, sizeof(struct sockaddr_storage));
+	copy_sockaddr(&link->src_addr, src_addr);
 
 	err = knet_addrtostr(src_addr, sizeof(struct sockaddr_storage),
 			     link->status.src_ipaddr, KNET_MAX_HOST_LEN,
@@ -237,7 +237,7 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 
 		link->dynamic = KNET_LINK_STATIC;
 
-		memmove(&link->dst_addr, dst_addr, sizeof(struct sockaddr_storage));
+		copy_sockaddr(&link->dst_addr, dst_addr);
 		err = knet_addrtostr(dst_addr, sizeof(struct sockaddr_storage),
 				     link->status.dst_ipaddr, KNET_MAX_HOST_LEN,
 				     link->status.dst_port, KNET_MAX_PORT_LEN);

--- a/libknet/links_acl_ip.c
+++ b/libknet/links_acl_ip.c
@@ -253,8 +253,8 @@ int ipcheck_addip(void *fd_tracker_match_entry_head, int index,
 		return -1;
 	}
 
-	memmove(&new_match_entry->addr1, ss1, sizeof(struct sockaddr_storage));
-	memmove(&new_match_entry->addr2, ss2, sizeof(struct sockaddr_storage));
+	copy_sockaddr(&new_match_entry->addr1, ss1);
+	copy_sockaddr(&new_match_entry->addr2, ss2);
 	new_match_entry->type = type;
 	new_match_entry->acceptreject = acceptreject;
 	new_match_entry->next = NULL;

--- a/libknet/netutils.c
+++ b/libknet/netutils.c
@@ -46,6 +46,13 @@ socklen_t sockaddr_len(const struct sockaddr_storage *ss)
 	}
 }
 
+/* Only copy the valid parts of a sockaddr* */
+void copy_sockaddr(struct sockaddr_storage *sout, const struct sockaddr_storage *sin)
+{
+	memset(sout, 0, sizeof(struct sockaddr_storage));
+	memmove(sout, sin, sockaddr_len(sin));
+}
+
 /*
  * exported APIs
  */

--- a/libknet/netutils.h
+++ b/libknet/netutils.h
@@ -25,5 +25,7 @@
 
 int cmpaddr(const struct sockaddr_storage *ss1, const struct sockaddr_storage *ss2);
 
+void copy_sockaddr(struct sockaddr_storage *sout, const struct sockaddr_storage *sin);
+
 socklen_t sockaddr_len(const struct sockaddr_storage *ss);
 #endif


### PR DESCRIPTION
Before we used to copy the whole sockaddr_storage from
the API into our structs. This meant that any junk left
at the end by the caller got into them and could
cause trouble with some comparisons.

This patch zeros out the extra bits of the sockaddr_storage
that are not valid.