### PR TITLE
Test fixups

### DIFF
--- a/libnozzle/tests/api_nozzle_add_ip.c
+++ b/libnozzle/tests/api_nozzle_add_ip.c
@@ -283,6 +283,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	make_local_ips(testipv4_1, testipv4_2, testipv6_1, testipv6_2);
 

--- a/libnozzle/tests/api_nozzle_close.c
+++ b/libnozzle/tests/api_nozzle_close.c
@@ -117,6 +117,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	make_local_ips(testipv4_1, testipv4_2, testipv6_1, testipv6_2);
 

--- a/libnozzle/tests/api_nozzle_del_ip.c
+++ b/libnozzle/tests/api_nozzle_del_ip.c
@@ -256,6 +256,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	make_local_ips(testipv4_1, testipv4_2, testipv6_1, testipv6_2);
 

--- a/libnozzle/tests/api_nozzle_get_fd.c
+++ b/libnozzle/tests/api_nozzle_get_fd.c
@@ -69,6 +69,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_get_handle_by_name.c
+++ b/libnozzle/tests/api_nozzle_get_handle_by_name.c
@@ -77,6 +77,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_get_ips.c
+++ b/libnozzle/tests/api_nozzle_get_ips.c
@@ -172,6 +172,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	make_local_ips(testipv4_1, testipv4_2, testipv6_1, testipv6_2);
 

--- a/libnozzle/tests/api_nozzle_get_mac.c
+++ b/libnozzle/tests/api_nozzle_get_mac.c
@@ -122,6 +122,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_get_mtu.c
+++ b/libnozzle/tests/api_nozzle_get_mtu.c
@@ -90,6 +90,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_get_name_by_handle.c
+++ b/libnozzle/tests/api_nozzle_get_name_by_handle.c
@@ -70,6 +70,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_open.c
+++ b/libnozzle/tests/api_nozzle_open.c
@@ -191,6 +191,7 @@ static int test(void)
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_run_updown.c
+++ b/libnozzle/tests/api_nozzle_run_updown.c
@@ -380,8 +380,7 @@ out_clean:
 	if (tmpdir) {
 		snprintf(tmpstr, sizeof(tmpstr) - 1, "rm -rf %s", tmpdir);
 		printf("Removing temporary dir: %s\n", tmpstr);
-		err = execute_bin_sh_command(tmpstr, &error_string);
-		if (err) {
+		if (execute_bin_sh_command(tmpstr, &error_string)) {
 			printf("Error removing directory: %s\n", error_string);
 		}
 		if (error_string) {

--- a/libnozzle/tests/api_nozzle_run_updown.c
+++ b/libnozzle/tests/api_nozzle_run_updown.c
@@ -398,6 +398,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_set_down.c
+++ b/libnozzle/tests/api_nozzle_set_down.c
@@ -118,6 +118,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_set_mac.c
+++ b/libnozzle/tests/api_nozzle_set_mac.c
@@ -150,6 +150,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/api_nozzle_set_mtu.c
+++ b/libnozzle/tests/api_nozzle_set_mtu.c
@@ -284,6 +284,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	make_local_ips(testipv4_1, testipv4_2, testipv6_1, testipv6_2);
 

--- a/libnozzle/tests/api_nozzle_set_up.c
+++ b/libnozzle/tests/api_nozzle_set_up.c
@@ -92,6 +92,7 @@ out_clean:
 int main(void)
 {
 	need_root();
+	need_tun();
 
 	if (test() < 0)
 		return FAIL;

--- a/libnozzle/tests/nozzle_run_updown_exit_false
+++ b/libnozzle/tests/nozzle_run_updown_exit_false
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # Copyright (C) 2010-2021 Red Hat, Inc.  All rights reserved.

--- a/libnozzle/tests/nozzle_run_updown_exit_true
+++ b/libnozzle/tests/nozzle_run_updown_exit_true
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # Copyright (C) 2010-2021 Red Hat, Inc.  All rights reserved.

--- a/libnozzle/tests/test-common.h
+++ b/libnozzle/tests/test-common.h
@@ -28,6 +28,7 @@
 #define IPBUFSIZE 1024
 
 void need_root(void);
+void need_tun(void);
 int test_iface(char *name, size_t size, const char *updownpath);
 int is_if_in_system(char *name);
 int get_random_byte(void);


### PR DESCRIPTION
Just a couple of things I needed to properly skip the unsupported tests on Debian buildds.
I don't know offhand how `need_tun()` should be implemented for BSDs (the kfreebsd port does not even have `sys/sockio.h`, so I can't readily test there), but we can try to work that out if needed.