### PR TITLE
libknet/tests: Correct include path for poll.h

### DIFF
--- a/libknet/tests/test-common.c
+++ b/libknet/tests/test-common.c
@@ -20,7 +20,7 @@
 #include <pthread.h>
 #include <dirent.h>
 #include <sys/select.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include "libknet.h"
 #include "test-common.h"


### PR DESCRIPTION
Fixes
/usr/include/sys/poll.h:1:2: error: redirec
ting incorrect #include <sys/poll.h> to <poll.h> [-Werror,-W#warnings]
| #warning redirecting incorrect #include <sys/poll.h> to <poll.h>

Signed-off-by: Khem Raj <raj.khem@gmail.com>