### PR TITLE
[UDP] Check for EHOSTUNREACH

### DIFF
--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -438,7 +438,8 @@ transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int soc
 			return KNET_TRANSPORT_SOCK_ERROR_IGNORE;
 		}
 		if ((recv_errno == EINVAL) || (recv_errno == EPERM) ||
-		    (recv_errno == ENETUNREACH) || (recv_errno == ENETDOWN)) {
+		    (recv_errno == ENETUNREACH) || (recv_errno == ENETDOWN) ||
+		    (recv_errno == EHOSTUNREACH)) {
 #ifdef DEBUG
 			if ((recv_errno == ENETUNREACH) || (recv_errno == ENETDOWN)) {
 				log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Sock: %d is unreachable.", sockfd);


### PR DESCRIPTION
EHOSTUNREACH seems to have been missed from the list of errors
checked at transmit time, so add it. Without this,
knet can spin under some conditions. (see issue #373)