### PR TITLE
[tests] deal with new annocheck symlink checks

### DIFF
--- a/build-aux/check.mk
+++ b/build-aux/check.mk
@@ -53,8 +53,9 @@ endif
 check-annocheck-libs:
 if HAS_ANNOCHECK
 	@echo Running annocheck libs test
-	if ! $(ANNOCHECK_EXEC) --skip-lto --quiet .libs/*.so; then \
-		$(ANNOCHECK_EXEC) --skip-lto --verbose .libs/*.so; \
+	TESTLIBS="$(shell find .libs/ -type f -name "*.so.*")"; \
+	if ! $(ANNOCHECK_EXEC) --skip-lto --quiet $$TESTLIBS; then \
+		$(ANNOCHECK_EXEC) --skip-lto --verbose $$TESTLIBS; \
 		echo annocheck libs test: FAILED; \
 		exit 1; \
 	else \
@@ -70,8 +71,9 @@ endif
 check-annocheck-bins:
 if HAS_ANNOCHECK
 	@echo Running annocheck binaries test
-	if ! $(ANNOCHECK_EXEC) --skip-run-path --skip-lto --quiet .libs/*; then \
-		$(ANNOCHECK_EXEC) --skip-run-path --skip-lto --verbose .libs/*; \
+	TESTBINS="$(shell find .libs/ -type f)"; \
+	if ! $(ANNOCHECK_EXEC) --skip-run-path --skip-lto --quiet $$TESTBINS; then \
+		$(ANNOCHECK_EXEC) --skip-run-path --skip-lto --verbose $$TESTBINS; \
 		echo annocheck binaries test: FAILED; \
 		exit 1; \
 	else \


### PR DESCRIPTION
command line has changed between f35 and rawhide, so go for
a neutral solution

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>