### PR TITLE
[tx] fix epoll event size to cope with extra event on send to link

### DIFF
--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -748,7 +748,7 @@ static void _handle_send_to_links(knet_handle_t knet_h, int sockfd, uint8_t onwi
 void *_handle_send_to_links_thread(void *data)
 {
 	knet_handle_t knet_h = (knet_handle_t) data;
-	struct epoll_event events[KNET_EPOLL_MAX_EVENTS];
+	struct epoll_event events[KNET_EPOLL_MAX_EVENTS + 1]; /* see _init_epolls for + 1 */
 	int i, nev;
 	int flush, flush_queue_limit;
 	int8_t channel;


### PR DESCRIPTION
spotted by -Werror=stringop-overflow= new gcc feature

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>