### PR TITLE
links.c: Fix build with gcc-12

### DIFF
--- a/libknet/links.c
+++ b/libknet/links.c
@@ -123,7 +123,7 @@ int knet_link_set_config(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t l
 {
 	int savederrno = 0, err = 0, i, wipelink = 0, link_idx;
 	struct knet_host *host, *tmp_host;
-	struct knet_link *link;
+	struct knet_link *link = NULL;
 
 	if (!_is_valid_handle(knet_h)) {
 		return -1;


### PR DESCRIPTION
Fix the build failure with gcc-12 when -Og pass to CFLAGS.
  | /build/tmp-glibc/work/corei7-64-wrs-linux/kronosnet/1.22-r0/recipe-sysroot/usr/include/bits/string_fortified.h:59:10: error: 'link' may be used uninitialized [-Werror=maybe-uninitialized]
  |    59 |   return __builtin___memset_chk (__dest, __ch, __len,
  |       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  |    60 |                                  __glibc_objsize0 (__dest));
  |       |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
  | ../../git/libknet/links.c: In function 'knet_link_set_config':
  | ../../git/libknet/links.c:108:27: note: 'link' was declared here
  |   108 |         struct knet_link *link;
  |       |                           ^~~~
  | cc1: all warnings being treated as errors

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>