### PR TITLE
configure: Conditionalize AC_PROG_CC_C99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_PROG_GREP
 AC_PROG_SED
 AC_PROG_CPP
 AC_PROG_CC
-AC_PROG_CC_C99
+m4_version_prereq([2.70], [:], [AC_PROG_CC_C99])
 if test "x$ac_cv_prog_cc_c99" = "xno"; then
 	AC_MSG_ERROR(["C99 support is required"])
 fi


### PR DESCRIPTION
Autoconf 2.70 made AC_PROG_CC_C99 deprecated because
AC_PROG_CC is performing same set of tests and sets same
variables.

To remove warning, conditionalize AC_PROG_CC_C99.

There is still one warning left caused by AX_PTHREAD, but this is problem with AX_PTHREAD and fixed upstream (-> it will disappears itself one day)

(this is much simpler version of libqb, corosync, qdevice, booth patch)