### PR TITLE
pmtud: Reset/restart pmtud when a node joins

### DIFF
--- a/libknet/crypto.c
+++ b/libknet/crypto.c
@@ -145,7 +145,7 @@ static int crypto_use_config(
 		knet_h->sec_salt_size = 0;
 	}
 
-	force_pmtud_run(knet_h, KNET_SUB_CRYPTO, 1);
+	force_pmtud_run(knet_h, KNET_SUB_CRYPTO, 1, 0);
 
 	return 0;
 }

--- a/libknet/links.c
+++ b/libknet/links.c
@@ -64,6 +64,10 @@ int _link_updown(knet_handle_t knet_h, knet_node_id_t host_id, uint8_t link_id,
 
 	if (!connected) {
 		transport_link_is_down(knet_h, link);
+	} else {
+		/* Reset MTU in case new link can't use full line MTU */
+		log_info(knet_h, KNET_SUB_LINK, "Resetting MTU for link %u because host %u joined", link_id, host_id);
+		force_pmtud_run(knet_h, KNET_SUB_LINK, 1, 1);
 	}
 
 	if (lock_stats) {

--- a/libknet/threads_common.c
+++ b/libknet/threads_common.c
@@ -38,13 +38,8 @@ int shutdown_in_progress(knet_handle_t knet_h)
 	return ret;
 }
 
-static int pmtud_reschedule(knet_handle_t knet_h)
+static int _pmtud_reschedule(knet_handle_t knet_h)
 {
-	if (pthread_mutex_lock(&knet_h->pmtud_mutex) != 0) {
-		log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get mutex lock");
-		return -1;
-	}
-
 	if (knet_h->pmtud_running) {
 		knet_h->pmtud_abort = 1;
 
@@ -52,9 +47,20 @@ static int pmtud_reschedule(knet_handle_t knet_h)
 			pthread_cond_signal(&knet_h->pmtud_cond);
 		}
 	}
-
-	pthread_mutex_unlock(&knet_h->pmtud_mutex);
 	return 0;
+}
+
+static int pmtud_reschedule(knet_handle_t knet_h)
+{
+	int res;
+
+	if (pthread_mutex_lock(&knet_h->pmtud_mutex) != 0) {
+		log_debug(knet_h, KNET_SUB_PMTUD, "Unable to get mutex lock");
+		return -1;
+	}
+	res = _pmtud_reschedule(knet_h);
+	pthread_mutex_unlock(&knet_h->pmtud_mutex);
+	return res;
 }
 
 int get_global_wrlock(knet_handle_t knet_h)
@@ -220,7 +226,7 @@ int wait_all_threads_status(knet_handle_t knet_h, uint8_t status)
 	return 0;
 }
 
-void force_pmtud_run(knet_handle_t knet_h, uint8_t subsystem, uint8_t reset_mtu)
+void force_pmtud_run(knet_handle_t knet_h, uint8_t subsystem, uint8_t reset_mtu, uint8_t force_restart)
 {
 	if (reset_mtu) {
 		log_debug(knet_h, subsystem, "PMTUd has been reset to default");
@@ -243,6 +249,12 @@ void force_pmtud_run(knet_handle_t knet_h, uint8_t subsystem, uint8_t reset_mtu)
 			if (!knet_h->pmtud_forcerun) {
 				log_debug(knet_h, subsystem, "Notifying PMTUd to rerun");
 				knet_h->pmtud_forcerun = 1;
+			}
+		} else {
+			if (force_restart) {
+				if (_pmtud_reschedule(knet_h) < 0) {
+					log_info(knet_h, KNET_SUB_PMTUD, "Unable to notify PMTUd to reschedule. A joining node may struggle to connect properly");
+				}
 			}
 		}
 		pthread_mutex_unlock(&knet_h->pmtud_mutex);

--- a/libknet/threads_common.h
+++ b/libknet/threads_common.h
@@ -49,7 +49,7 @@ int set_thread_flush_queue(knet_handle_t knet_h, uint8_t thread_id, uint8_t stat
 int wait_all_threads_flush_queue(knet_handle_t knet_h);
 int set_thread_status(knet_handle_t knet_h, uint8_t thread_id, uint8_t status);
 int wait_all_threads_status(knet_handle_t knet_h, uint8_t status);
-void force_pmtud_run(knet_handle_t knet_h, uint8_t subsystem, uint8_t reset_mtu);
+void force_pmtud_run(knet_handle_t knet_h, uint8_t subsystem, uint8_t reset_mtu, uint8_t force_restart);
 uint32_t compute_chksum(const unsigned char *data, uint32_t data_len);
 uint32_t compute_chksumv(const struct iovec *iov_in, int iovcnt_in);
 

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -899,7 +899,7 @@ int knet_handle_pmtud_set(knet_handle_t knet_h,
 
 	knet_h->manual_mtu = iface_mtu;
 
-	force_pmtud_run(knet_h, KNET_SUB_PMTUD, 0);
+	force_pmtud_run(knet_h, KNET_SUB_PMTUD, 0, 0);
 
 	pthread_rwlock_unlock(&knet_h->global_rwlock);
 

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -343,7 +343,7 @@ static int read_errs_from_sock(knet_handle_t knet_h, int sockfd)
 									pthread_mutex_unlock(&knet_h->kmtu_mutex);
 								}
 
-								force_pmtud_run(knet_h, KNET_SUB_TRANSP_UDP, 0);
+								force_pmtud_run(knet_h, KNET_SUB_TRANSP_UDP, 0, 0);
 							}
 							/*
 							 * those errors are way too noisy


### PR DESCRIPTION
If a new node joins with a 'black hole' that sets the effective MTU to be less than the hardware MTU then it will fail to join.

So this patch restarts the pMTUd processes each time a new node joins so it has a chance to declare it's real MTU in time.