### PR TITLE
udp: Move EPERM to be alongside EMSGSIZE in tx error handler

### DIFF
--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -466,7 +466,7 @@ typedef struct knet_transport_ops {
  * it should return a transport_sock_error_t
  *    any sleep or wait action should happen inside the transport code
  */
-	transport_sock_error_t (*transport_tx_sock_error)(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
+	transport_sock_error_t (*transport_tx_sock_error)(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno);
 
 /*
  * this function is called on _every_ received packet

--- a/libknet/threads_heartbeat.c
+++ b/libknet/threads_heartbeat.c
@@ -129,7 +129,7 @@ retry:
 		dst_link->status.stats.tx_ping_bytes += outlen;
 
 		if (len != outlen) {
-			err = transport_tx_sock_error(knet_h, dst_link->transport, dst_link->outsock, len, savederrno);
+			err = transport_tx_sock_error(knet_h, dst_link->transport, dst_link->outsock, KNET_SUB_HEARTBEAT, len, savederrno);
 			switch(err) {
 				case KNET_TRANSPORT_SOCK_ERROR_INTERNAL:
 					log_debug(knet_h, KNET_SUB_HEARTBEAT,
@@ -209,7 +209,7 @@ retry:
 		}
 		savederrno = errno;
 		if (len != outlen) {
-			err = transport_tx_sock_error(knet_h, src_link->transport, src_link->outsock, len, savederrno);
+			err = transport_tx_sock_error(knet_h, src_link->transport, src_link->outsock, KNET_SUB_HEARTBEAT, len, savederrno);
 			switch(err) {
 				case KNET_TRANSPORT_SOCK_ERROR_INTERNAL:
 					log_debug(knet_h, KNET_SUB_HEARTBEAT,

--- a/libknet/threads_pmtud.c
+++ b/libknet/threads_pmtud.c
@@ -247,7 +247,7 @@ retry:
 
 	kernel_mtu = 0;
 
-	err = transport_tx_sock_error(knet_h, dst_link->transport, dst_link->outsock, len, savederrno);
+	err = transport_tx_sock_error(knet_h, dst_link->transport, dst_link->outsock, KNET_SUB_PMTUD, len, savederrno);
 	switch(err) {
 		case KNET_TRANSPORT_SOCK_ERROR_INTERNAL:
 			log_debug(knet_h, KNET_SUB_PMTUD, "Unable to send pmtu packet (sendto): %d %s", savederrno, strerror(savederrno));
@@ -269,7 +269,7 @@ retry:
 
 	if (len != (ssize_t )data_len) {
 		pthread_mutex_unlock(&dst_link->link_stats_mutex);
-		if (savederrno == EMSGSIZE) {
+		if (savederrno == EMSGSIZE || savederrno == EPERM) {
 			/*
 			 * we cannot hold a lock on kmtu_mutex between resetting
 			 * knet_h->kernel_mtu and here.
@@ -713,7 +713,7 @@ retry:
 		}
 		savederrno = errno;
 		if (len != outlen) {
-			err = transport_tx_sock_error(knet_h, src_link->transport, src_link->outsock, len, savederrno);
+			err = transport_tx_sock_error(knet_h, src_link->transport, src_link->outsock, KNET_SUB_PMTUD, len, savederrno);
 			stats_err = pthread_mutex_lock(&src_link->link_stats_mutex);
 			if (stats_err < 0) {
 				log_err(knet_h, KNET_SUB_PMTUD, "Unable to get mutex lock: %s", strerror(stats_err));

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -81,7 +81,7 @@ retry:
 				      &cur[0], msgs_to_send - prev_sent, MSG_DONTWAIT | MSG_NOSIGNAL);
 		savederrno = errno;
 
-		err = transport_tx_sock_error(knet_h, dst_host->link[dst_host->active_links[link_idx]].transport, dst_host->link[dst_host->active_links[link_idx]].outsock, sent_msgs, savederrno);
+		err = transport_tx_sock_error(knet_h, dst_host->link[dst_host->active_links[link_idx]].transport, dst_host->link[dst_host->active_links[link_idx]].outsock, KNET_SUB_TX, sent_msgs, savederrno);
 		switch(err) {
 			case KNET_TRANSPORT_SOCK_ERROR_INTERNAL:
 				cur_link->status.stats.tx_data_errors++;

--- a/libknet/transport_loopback.c
+++ b/libknet/transport_loopback.c
@@ -59,7 +59,7 @@ int loopback_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_
 	return 0;
 }
 
-transport_sock_error_t loopback_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
+transport_sock_error_t loopback_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno)
 {
 	return KNET_TRANSPORT_SOCK_ERROR_IGNORE;
 }

--- a/libknet/transport_loopback.h
+++ b/libknet/transport_loopback.h
@@ -20,7 +20,7 @@ int loopback_transport_link_clear_config(knet_handle_t knet_h, struct knet_link 
 int loopback_transport_free(knet_handle_t knet_h);
 int loopback_transport_init(knet_handle_t knet_h);
 int loopback_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
-transport_sock_error_t loopback_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
+transport_sock_error_t loopback_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno);
 transport_rx_isdata_t loopback_transport_rx_is_data(knet_handle_t knet_h, int sockfd, struct knet_mmsghdr *msg);
 int loopback_transport_link_dyn_connect(knet_handle_t knet_h, int sockfd, struct knet_link *kn_link);
 int loopback_transport_link_is_down(knet_handle_t knet_h, struct knet_link *kn_link);

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -321,7 +321,7 @@ static void _lock_sleep_relock(knet_handle_t knet_h)
 	assert(0);
 }
 
-int sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
+int sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno)
 {
 	sctp_connect_link_info_t *connect_info = knet_h->knet_transport_fd_tracker[sockfd].data;
 	sctp_accepted_link_info_t *accepted_info = knet_h->knet_transport_fd_tracker[sockfd].data;

--- a/libknet/transport_sctp.h
+++ b/libknet/transport_sctp.h
@@ -28,7 +28,7 @@ int sctp_transport_link_clear_config(knet_handle_t knet_h, struct knet_link *kn_
 int sctp_transport_free(knet_handle_t knet_h);
 int sctp_transport_init(knet_handle_t knet_h);
 int sctp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
-transport_sock_error_t sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
+transport_sock_error_t sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno);
 transport_rx_isdata_t sctp_transport_rx_is_data(knet_handle_t knet_h, int sockfd, struct knet_mmsghdr *msg);
 int sctp_transport_link_dyn_connect(knet_handle_t knet_h, int sockfd, struct knet_link *kn_link);
 int sctp_transport_link_is_down(knet_handle_t knet_h, struct knet_link *kn_link);

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -332,7 +332,7 @@ static int read_errs_from_sock(knet_handle_t knet_h, int sockfd)
 					switch (sock_err->ee_origin) {
 						case SO_EE_ORIGIN_NONE: /* no origin */
 						case SO_EE_ORIGIN_LOCAL: /* local source (EMSGSIZE) */
-							if (sock_err->ee_errno == EMSGSIZE) {
+							if (sock_err->ee_errno == EMSGSIZE || sock_err->ee_errno == EPERM) {
 								if (pthread_mutex_lock(&knet_h->kmtu_mutex) != 0) {
 									log_debug(knet_h, KNET_SUB_TRANSP_UDP, "Unable to get mutex lock");
 									knet_h->kernel_mtu = 0;
@@ -430,10 +430,11 @@ int udp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, 
 	return 0;
 }
 
-transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
+transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno)
 {
 	if (recv_err < 0) {
-		if (recv_errno == EMSGSIZE) {
+		log_debug(knet_h, KNET_SUB_TRANSP_UDP, "tx_sock_error, subsys=%d, recv_err=%d, recv_errno=%d", subsys, recv_err, recv_errno);
+		if ((recv_errno == EMSGSIZE) || ((recv_errno == EPERM) && ((subsys == KNET_SUB_TX) || (subsys == KNET_SUB_PMTUD)))) {
 			read_errs_from_sock(knet_h, sockfd);
 			return KNET_TRANSPORT_SOCK_ERROR_IGNORE;
 		}

--- a/libknet/transport_udp.h
+++ b/libknet/transport_udp.h
@@ -20,7 +20,7 @@ int udp_transport_link_clear_config(knet_handle_t knet_h, struct knet_link *kn_l
 int udp_transport_free(knet_handle_t knet_h);
 int udp_transport_init(knet_handle_t knet_h);
 int udp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
-transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
+transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno);
 transport_rx_isdata_t udp_transport_rx_is_data(knet_handle_t knet_h, int sockfd, struct knet_mmsghdr *msg);
 int udp_transport_link_dyn_connect(knet_handle_t knet_h, int sockfd, struct knet_link *kn_link);
 int udp_transport_link_is_down(knet_handle_t knet_h, struct knet_link *kn_link);

--- a/libknet/transports.c
+++ b/libknet/transports.c
@@ -108,9 +108,9 @@ int transport_rx_sock_error(knet_handle_t knet_h, uint8_t transport, int sockfd,
 	return transport_modules_cmd[transport].transport_rx_sock_error(knet_h, sockfd, recv_err, recv_errno);
 }
 
-int transport_tx_sock_error(knet_handle_t knet_h, uint8_t transport, int sockfd, int recv_err, int recv_errno)
+	int transport_tx_sock_error(knet_handle_t knet_h, uint8_t transport, int sockfd, int subsys, int recv_err, int recv_errno)
 {
-	return transport_modules_cmd[transport].transport_tx_sock_error(knet_h, sockfd, recv_err, recv_errno);
+	return transport_modules_cmd[transport].transport_tx_sock_error(knet_h, sockfd, subsys, recv_err, recv_errno);
 }
 
 int transport_rx_is_data(knet_handle_t knet_h, uint8_t transport, int sockfd, struct knet_mmsghdr *msg)

--- a/libknet/transports.h
+++ b/libknet/transports.h
@@ -16,7 +16,7 @@ int transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_link, u
 int transport_link_clear_config(knet_handle_t knet_h, struct knet_link *kn_link);
 int transport_link_dyn_connect(knet_handle_t knet_h, int sockfd, struct knet_link *kn_link);
 int transport_rx_sock_error(knet_handle_t knet_h, uint8_t transport, int sockfd, int recv_err, int recv_errno);
-int transport_tx_sock_error(knet_handle_t knet_h, uint8_t transport, int sockfd, int recv_err, int recv_errno);
+int transport_tx_sock_error(knet_handle_t knet_h, uint8_t transport, int sockfd, int subsys, int recv_err, int recv_errno);
 int transport_rx_is_data(knet_handle_t knet_h, uint8_t transport, int sockfd, struct knet_mmsghdr *msg);
 int transport_get_proto(knet_handle_t knet_h, uint8_t transport);
 int transport_get_acl_type(knet_handle_t knet_h, uint8_t transport);


### PR DESCRIPTION
EPERM can be returned (tested Linux 5.19 & FreeBSD 13) when a packet is transmitted that is too large for the i/f MTU or an iptables transmit rule - so it makes sense to treat it like EMSGSIZE and trigger a pMTU run