### PR TITLE
rust: Fix bindgen call

### DIFF
--- a/build-aux/rust-regen.sh
+++ b/build-aux/rust-regen.sh
@@ -17,13 +17,13 @@ filter="$3"
 
 bindgen \
 	--size_t-is-usize \
-	--no-recursive-whitelist \
+	--no-recursive-allowlist \
 	--no-prepend-enum-name \
 	--no-layout-tests \
 	--no-doc-comments \
 	--generate functions,types,vars \
 	--fit-macro-constant-types \
-	--whitelist-var=$3.*  \
-	--whitelist-type=.* \
-	--whitelist-function=*. \
+	--allowlist-var=$3.*  \
+	--allowlist-type=.* \
+	--allowlist-function=.* \
 	$srcheader -o $dstrs


### PR DESCRIPTION
the *whitelist* command options have been superceded by *allowlist* ones, and the *whitelist* ones are now removed in Fedora rawhide.