### PR TITLE
transport: fix gcc-13 compliation

### DIFF
--- a/libknet/transport_loopback.c
+++ b/libknet/transport_loopback.c
@@ -54,9 +54,9 @@ int loopback_transport_init(knet_handle_t knet_h)
 	return 0;
 }
 
-int loopback_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
+transport_sock_error_t loopback_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
 {
-	return 0;
+	return KNET_TRANSPORT_SOCK_ERROR_IGNORE;
 }
 
 transport_sock_error_t loopback_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno)

--- a/libknet/transport_loopback.h
+++ b/libknet/transport_loopback.h
@@ -19,7 +19,7 @@ int loopback_transport_link_set_config(knet_handle_t knet_h, struct knet_link *k
 int loopback_transport_link_clear_config(knet_handle_t knet_h, struct knet_link *kn_link);
 int loopback_transport_free(knet_handle_t knet_h);
 int loopback_transport_init(knet_handle_t knet_h);
-int loopback_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
+transport_sock_error_t loopback_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
 transport_sock_error_t loopback_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno);
 transport_rx_isdata_t loopback_transport_rx_is_data(knet_handle_t knet_h, int sockfd, struct knet_mmsghdr *msg);
 int loopback_transport_link_dyn_connect(knet_handle_t knet_h, int sockfd, struct knet_link *kn_link);

--- a/libknet/transport_sctp.c
+++ b/libknet/transport_sctp.c
@@ -321,7 +321,7 @@ static void _lock_sleep_relock(knet_handle_t knet_h)
 	assert(0);
 }
 
-int sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno)
+transport_sock_error_t sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno)
 {
 	sctp_connect_link_info_t *connect_info = knet_h->knet_transport_fd_tracker[sockfd].data;
 	sctp_accepted_link_info_t *accepted_info = knet_h->knet_transport_fd_tracker[sockfd].data;

--- a/libknet/transport_sctp.h
+++ b/libknet/transport_sctp.h
@@ -27,7 +27,7 @@ int sctp_transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_li
 int sctp_transport_link_clear_config(knet_handle_t knet_h, struct knet_link *kn_link);
 int sctp_transport_free(knet_handle_t knet_h);
 int sctp_transport_init(knet_handle_t knet_h);
-int sctp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
+transport_sock_error_t sctp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
 transport_sock_error_t sctp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno);
 transport_rx_isdata_t sctp_transport_rx_is_data(knet_handle_t knet_h, int sockfd, struct knet_mmsghdr *msg);
 int sctp_transport_link_dyn_connect(knet_handle_t knet_h, int sockfd, struct knet_link *kn_link);

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -422,12 +422,12 @@ static int read_errs_from_sock(knet_handle_t knet_h, int sockfd)
 }
 #endif
 
-int udp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
+transport_sock_error_t udp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno)
 {
 	if (recv_errno == EAGAIN) {
 		read_errs_from_sock(knet_h, sockfd);
 	}
-	return 0;
+	return KNET_TRANSPORT_SOCK_ERROR_IGNORE;
 }
 
 transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno)

--- a/libknet/transport_udp.h
+++ b/libknet/transport_udp.h
@@ -19,7 +19,7 @@ int udp_transport_link_set_config(knet_handle_t knet_h, struct knet_link *kn_lin
 int udp_transport_link_clear_config(knet_handle_t knet_h, struct knet_link *kn_link);
 int udp_transport_free(knet_handle_t knet_h);
 int udp_transport_init(knet_handle_t knet_h);
-int udp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
+transport_sock_error_t udp_transport_rx_sock_error(knet_handle_t knet_h, int sockfd, int recv_err, int recv_errno);
 transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int sockfd, int subsys, int recv_err, int recv_errno);
 transport_rx_isdata_t udp_transport_rx_is_data(knet_handle_t knet_h, int sockfd, struct knet_mmsghdr *msg);
 int udp_transport_link_dyn_connect(knet_handle_t knet_h, int sockfd, struct knet_link *kn_link);


### PR DESCRIPTION
We had a mixture of enum and ints being returned from the [rt]x_sock_error calls, and gcc-13 doesn't like that. So make it all nice and consistent.