### PR TITLE
rust - make it work on FreeBSD

### DIFF
--- a/libknet/bindings/rust/src/knet_bindings.rs
+++ b/libknet/bindings/rust/src/knet_bindings.rs
@@ -1748,6 +1748,15 @@ impl AclCheckType {
 fn make_new_sockaddr_storage(ss: &SocketAddr) -> ffi::sockaddr_storage
 {
     // A blank one
+#[cfg(any(target_os="freebsd"))]
+    let mut new_ss = ffi::sockaddr_storage {
+	ss_family: 0,
+	ss_len: 0,
+	__ss_pad1: [0; 6],
+	__ss_align: 0,
+	__ss_pad2: [0; 112],
+    };
+#[cfg(any(target_os="linux"))]
     let mut new_ss = ffi::sockaddr_storage {
 	ss_family: 0,
 	__ss_padding: [0; 118],


### PR DESCRIPTION
I'm not massively happy about hard-coding these numbers into sockaddr_storage, but as the struct is read from the header file in C programs, it's not going to change in a hurry.