### PR TITLE
Rust: Remove obsolete bindgen flag

### DIFF
--- a/build-aux/rust-regen.sh
+++ b/build-aux/rust-regen.sh
@@ -16,7 +16,6 @@ dstrs="$2"
 filter="$3"
 
 bindgen \
-	--size_t-is-usize \
 	--no-prepend-enum-name \
 	--no-layout-tests \
 	--no-doc-comments \


### PR DESCRIPTION
--size_t-is-usize has been deprecated for a while and is removed in bindgen 0.64