### PR TITLE
[tx] Remove expensive memsets

### DIFF
--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -463,6 +463,8 @@ int knet_send_sync(knet_handle_t knet_h,
  *                                           packet
  *            knet_node_id_t *dst_host_ids - array of KNET_MAX_HOST knet_node_id_t
  *                                           where to store the destinations
+ *                                           (uninitialized by caller, callee should never
+ *                                           read it)
  *            size_t *dst_host_ids_entries - number of hosts to send the message
  *
  * dst_host_filter_fn should return

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -179,9 +179,6 @@ static int _parse_recv_from_sock(knet_handle_t knet_h, size_t inlen, int8_t chan
 		goto out_unlock;
 	}
 
-	memset(dst_host_ids_temp, 0, sizeof(dst_host_ids_temp));
-	memset(dst_host_ids, 0, sizeof(dst_host_ids));
-
 	/*
 	 * move this into a separate function to expand on
 	 * extra switching rules


### PR DESCRIPTION
Memset of dst_host_ids is relatively expensive because structure is large (128KiB) and it is not really needed because it is always fully set later.