### PR TITLE
nozzle: tests: Fix 'set_down' test on FreeBSD-devel

### DIFF
--- a/libknet/bindings/rust/Makefile.am
+++ b/libknet/bindings/rust/Makefile.am
@@ -29,9 +29,9 @@ RUST_SHIP_SRCS		= \
 RUST_BUILT_SRCS		= \
 			  src/sys/libknet.rs
 
-src/sys/libknet.rs: ../../libknet.h
-	$(top_srcdir)/build-aux/rust-regen.sh $^ $@ KNET
+src/sys/libknet.rs: cargo-tree-prep ../../libknet.h
+	$(top_srcdir)/build-aux/rust-regen.sh $(top_srcdir)/libknet/libknet.h $@ KNET
 
-all-local: cargo-tree-prep target/$(RUST_TARGET_DIR)/knet_bindings.rlib
+all-local: target/$(RUST_TARGET_DIR)/knet_bindings.rlib
 
 clean-local: cargo-clean

--- a/libnozzle/bindings/rust/Makefile.am
+++ b/libnozzle/bindings/rust/Makefile.am
@@ -29,9 +29,9 @@ RUST_SHIP_SRCS		= \
 RUST_BUILT_SRCS		= \
 			  src/sys/libnozzle.rs
 
-src/sys/libnozzle.rs: ../../libnozzle.h
-	$(top_srcdir)/build-aux/rust-regen.sh $^ $@ NOZZLE
+src/sys/libnozzle.rs: cargo-tree-prep ../../libnozzle.h
+	$(top_srcdir)/build-aux/rust-regen.sh $(top_srcdir)/libnozzle/libnozzle.h $@ NOZZLE
 
-all-local: cargo-tree-prep target/$(RUST_TARGET_DIR)/nozzle_bindings.rlib
+all-local: target/$(RUST_TARGET_DIR)/nozzle_bindings.rlib
 
 clean-local: cargo-clean

--- a/libnozzle/tests/api_nozzle_set_down.c
+++ b/libnozzle/tests/api_nozzle_set_down.c
@@ -51,7 +51,7 @@ static int test(void)
 		 "ip addr show dev %s | grep -q UP", nozzle->name);
 #endif
 #ifdef KNET_BSD
-		 "ifconfig %s | grep -q UP", nozzle->name);
+	         "ifconfig %s | sed -e 's/LOWER_UP/GROT/' | grep -q UP", nozzle->name);
 #endif
 	err = execute_bin_sh_command(verifycmd, &error_string);
 	if (error_string) {
@@ -80,7 +80,7 @@ static int test(void)
 		 "ip addr show dev %s | grep -q UP", nozzle->name);
 #endif
 #ifdef KNET_BSD
-		 "ifconfig %s | grep -q UP", nozzle->name);
+	         "ifconfig %s | sed -e 's/LOWER_UP/GROT/' | grep -q UP", nozzle->name);
 #endif
 	err = execute_bin_sh_command(verifycmd, &error_string);
 	if (error_string) {


### PR DESCRIPTION
The new FreeBSD adds a LOWER_UP flag to interfaces that indicates whether the driver is signalling L1 up. So we need to exclude that from our grep when checking the higher-level interface status.