### PR TITLE
[spec] Migrate to SPDX license

### DIFF
--- a/kronosnet.spec.in
+++ b/kronosnet.spec.in
@@ -44,7 +44,7 @@ Name: kronosnet
 Summary: Multipoint-to-Multipoint VPN daemon
 Version: @version@
 Release: 1%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?dist}
-License: GPLv2+ and LGPLv2+
+License: GPL-2.0-or-later AND LGPL-2.1-or-later
 URL: https://kronosnet.org
 Source0: https://kronosnet.org/releases/%{name}-%{version}%{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}.tar.gz
 
@@ -204,7 +204,7 @@ rm -rf %{buildroot}/usr/share/doc/kronosnet
 %if %{with libnozzle}
 %package -n libnozzle1
 Summary: Simple userland wrapper around kernel tap devices
-License: LGPLv2+
+License: LGPL-2.1-or-later
 
 %description -n libnozzle1
  This is an over-engineered commodity library to manage a pool
@@ -224,7 +224,7 @@ License: LGPLv2+
 
 %package -n libnozzle1-devel
 Summary: Simple userland wrapper around kernel tap devices (developer files)
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libnozzle1%{_isa} = %{version}-%{release}
 Requires: pkgconfig
 
@@ -245,7 +245,7 @@ Requires: pkgconfig
 
 %package -n libknet1
 Summary: Kronosnet core switching implementation
-License: LGPLv2+
+License: LGPL-2.1-or-later
 
 %description -n libknet1
  The whole kronosnet core is implemented in this library.
@@ -266,7 +266,7 @@ License: LGPLv2+
 
 %package -n libknet1-devel
 Summary: Kronosnet core switching implementation (developer files)
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 Requires: pkgconfig
 
@@ -287,7 +287,7 @@ Requires: pkgconfig
 %if %{with nss}
 %package -n libknet1-crypto-nss-plugin
 Summary: Provides libknet1 nss support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-crypto-nss-plugin
@@ -300,7 +300,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with openssl}
 %package -n libknet1-crypto-openssl-plugin
 Summary: Provides libknet1 openssl support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-crypto-openssl-plugin
@@ -313,7 +313,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with gcrypt}
 %package -n libknet1-crypto-gcrypt-plugin
 Summary: Provides libknet1 gcrypt support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-crypto-gcrypt-plugin
@@ -326,7 +326,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with zlib}
 %package -n libknet1-compress-zlib-plugin
 Summary: Provides libknet1 zlib support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-compress-zlib-plugin
@@ -339,7 +339,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with lz4}
 %package -n libknet1-compress-lz4-plugin
 Summary: Provides libknet1 lz4 and lz4hc support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-compress-lz4-plugin
@@ -353,7 +353,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with lzo2}
 %package -n libknet1-compress-lzo2-plugin
 Summary: Provides libknet1 lzo2 support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-compress-lzo2-plugin
@@ -366,7 +366,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with lzma}
 %package -n libknet1-compress-lzma-plugin
 Summary: Provides libknet1 lzma support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-compress-lzma-plugin
@@ -379,7 +379,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with bzip2}
 %package -n libknet1-compress-bzip2-plugin
 Summary: Provides libknet1 bzip2 support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-compress-bzip2-plugin
@@ -392,7 +392,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with zstd}
 %package -n libknet1-compress-zstd-plugin
 Summary: Provides libknet1 zstd support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 
 %description -n libknet1-compress-zstd-plugin
@@ -404,7 +404,7 @@ Requires: libknet1%{_isa} = %{version}-%{release}
 
 %package -n libknet1-crypto-plugins-all
 Summary: Provides libknet1 crypto plugins meta package
-License: LGPLv2+
+License: LGPL-2.1-or-later
 %if %{with nss}
 Requires: libknet1-crypto-nss-plugin%{_isa} = %{version}-%{release}
 %endif
@@ -422,7 +422,7 @@ Requires: libknet1-crypto-gcrypt-plugin%{_isa} = %{version}-%{release}
 
 %package -n libknet1-compress-plugins-all
 Summary: Provides libknet1 compress plugins meta package
-License: LGPLv2+
+License: LGPL-2.1-or-later
 %if %{with zlib}
 Requires: libknet1-compress-zlib-plugin%{_isa} = %{version}-%{release}
 %endif
@@ -449,7 +449,7 @@ Requires: libknet1-compress-zstd-plugin%{_isa} = %{version}-%{release}
 
 %package -n libknet1-plugins-all
 Summary: Provides libknet1 plugins meta package
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: libknet1-compress-plugins-all%{_isa} = %{version}-%{release}
 Requires: libknet1-crypto-plugins-all%{_isa} = %{version}-%{release}
 
@@ -461,7 +461,7 @@ Requires: libknet1-crypto-plugins-all%{_isa} = %{version}-%{release}
 %if %{with installtests}
 %package -n kronosnet-tests
 Summary: Provides kronosnet test suite
-License: GPLv2+
+License: GPL-2.0-or-later
 Requires: libknet1%{_isa} = %{version}-%{release}
 %if %{with libnozzle}
 Requires: libnozzle1%{_isa} = %{version}-%{release}


### PR DESCRIPTION
Both Fedora and openSUSE now recommends to use SPDX shortname format for License.