### PR TITLE
rust: Update to latest standards

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -506,7 +506,7 @@ if test -n "${SANITIZERS}"; then
 	done
 fi
 
-DEFAULT_CFLAGS="-Werror -Wall -Wextra"
+DEFAULT_CFLAGS="-Werror -Wall -Wextra -Wno-gnu-folding-constant"
 
 # manual overrides
 # generates too much noise for stub APIs

--- a/libknet/bindings/rust/Cargo.toml.in
+++ b/libknet/bindings/rust/Cargo.toml.in
@@ -8,7 +8,7 @@
 name = "knet-bindings"
 version = "@libknetrustver@"
 authors = ["Christine Caulfield <ccaulfie@redhat.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README"
 license = "LGPL-2.1+"
 repository = "https://github.com/kronosnet/kronosnet"
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "2.6.0"
 lazy_static = "1.4.0"
 os_socketaddr = "0.2.0"
 libc = "0.2.93"

--- a/libknet/bindings/rust/src/knet_bindings.rs
+++ b/libknet/bindings/rust/src/knet_bindings.rs
@@ -439,7 +439,7 @@ pub fn handle_new(host_id: &HostId,
 	ffi::knet_handle_new(host_id.host_id,
 			     log_fd,
 			     default_log_level.to_u8(),
-			     flags.bits)
+			     flags.bits())
     };
 
     if res.is_null() {
@@ -1660,7 +1660,7 @@ pub fn link_set_config(handle: &Handle, host_id: &HostId, link_id: u8,
 				      transport.to_u8(),
 				      &mut c_srcaddr,
 				      &mut c_dstaddr,
-				      flags.bits)
+				      flags.bits())
 	}
     } else {
 	unsafe {
@@ -1669,7 +1669,7 @@ pub fn link_set_config(handle: &Handle, host_id: &HostId, link_id: u8,
 				      transport.to_u8(),
 				      &mut c_srcaddr,
 				      null_mut(),
-				      flags.bits)
+				      flags.bits())
 	}
     };
     if res == 0 {
@@ -1700,7 +1700,7 @@ pub fn link_get_config(handle: &Handle, host_id: &HostId, link_id: u8) ->
     };
     if res == 0 {
 	let r_transport = TransportId::new(c_transport);
-	Ok((r_transport, c_srcaddr.into(), c_dstaddr.into(), LinkFlags{bits:c_flags}))
+	Ok((r_transport, c_srcaddr.into(), c_dstaddr.into(), LinkFlags::from_bits(c_flags).unwrap_or(LinkFlags::empty())))
     } else {
 	Err(Error::last_os_error())
     }

--- a/libknet/bindings/rust/tests/Cargo.toml.in
+++ b/libknet/bindings/rust/tests/Cargo.toml.in
@@ -8,7 +8,7 @@
 name = "knet-bindings-tests"
 version = "@libknetrustver@"
 authors = ["Christine Caulfield <ccaulfie@redhat.com>"]
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 cc = "1.0"

--- a/libnozzle/bindings/rust/Cargo.toml.in
+++ b/libnozzle/bindings/rust/Cargo.toml.in
@@ -8,7 +8,7 @@
 name = "nozzle-bindings"
 version = "@libnozzlerustver@"
 authors = ["Christine Caulfield <ccaulfie@redhat.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README"
 license = "LGPL-2.1+"
 repository = "https://github.com/kronosnet/kronosnet"
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "2.6.0"
 lazy_static = "1.4.0"
 os_socketaddr = "0.2.0"
 libc = "0.2.93"

--- a/libnozzle/bindings/rust/tests/Cargo.toml.in
+++ b/libnozzle/bindings/rust/tests/Cargo.toml.in
@@ -8,7 +8,7 @@
 name = "nozzle-bindings-tests"
 version = "@libnozzlerustver@"
 authors = ["Christine Caulfield <ccaulfie@redhat.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Updating to Rust 2021 is a no-op (but worth doing for future), I've also taken this opportunity to use the latest bitflags crate.