### PR TITLE
Fix writev all

### DIFF
--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -153,6 +153,7 @@ static int _dispatch_to_local(knet_handle_t knet_h, unsigned char *data, size_t 
 	if (knet_h->sockfd[channel].flags & KNET_DATAFD_FLAG_RX_RETURN_INFO) {
 		log_debug(knet_h, KNET_SUB_RX,
 			  "Adding header to local packet");
+		memset(&datafd_hdr, 0, sizeof(datafd_hdr));
 		datafd_hdr.size = sizeof(datafd_hdr);
 		datafd_hdr.src_nodeid = knet_h->host_id;
 		iov_out[0].iov_base = &datafd_hdr;

--- a/libknet/threads_tx.c
+++ b/libknet/threads_tx.c
@@ -151,8 +151,6 @@ static int _dispatch_to_local(knet_handle_t knet_h, unsigned char *data, size_t 
 	struct knet_datafd_header datafd_hdr;
 
 	if (knet_h->sockfd[channel].flags & KNET_DATAFD_FLAG_RX_RETURN_INFO) {
-		log_debug(knet_h, KNET_SUB_RX,
-			  "Adding header to local packet");
 		memset(&datafd_hdr, 0, sizeof(datafd_hdr));
 		datafd_hdr.size = sizeof(datafd_hdr);
 		datafd_hdr.src_nodeid = knet_h->host_id;


### PR DESCRIPTION
During implementation of usage of newly added `KNET_DATAFD_FLAG_RX_RETURN_INFO` functionality I found out corosync is crashing badly. It turned out it is problem in knet which (for some unknown reason) appears only when code is compiled with `--enable-debug` and it happens only when  `KNET_DATAFD_FLAG_RX_RETURN_INFO` is used. Good news was, that problem was happening also for `api_knet_recv_test`.

So running `api_knet_recv_test`

Ends with
```
...
FOE: wait_for_host(knet_h1, 1, 10, logfds[0], stdout)
[knet: 0x7f2b1335c010]: [debug] host: host_status_change_notify_fn enabled
[knet: 0x7f2b1335c010]: [debug] host: host_status_change_notify_fn disabled
knet_recv failed: Resource temporarily unavailable
*** stack smashing detected ***: terminated
Aborted (core dumped)
```

Valgrind gives a little bit more information
```
...
[knet: 0xb546040]: [debug] host: host_status_change_notify_fn enabled
[knet: 0xb546040]: [debug] host: host_status_change_notify_fn disabled
knet_recv failed: Resource temporarily unavailable
==236312== Thread 6:
==236312== Syscall param writev(vector[0]) points to uninitialised byte(s)
==236312==    at 0x49DF31D: writev (in /usr/lib64/libc.so.6)
==236312==    by 0x48807A1: writev_all (transport_common.c:466)
==236312==    by 0x487C754: _dispatch_to_local (threads_tx.c:165)
==236312==    by 0x487DD2E: _parse_recv_from_sock (threads_tx.c:634)
==236312==    by 0x487E2C9: _handle_send_to_links (threads_tx.c:737)
==236312==    by 0x487E6C3: _handle_send_to_links_thread (threads_tx.c:833)
==236312==    by 0x493A801: start_thread (in /usr/lib64/libc.so.6)
==236312==    by 0x48DA313: clone (in /usr/lib64/libc.so.6)
==236312==  Address 0xb421a7a is on thread 6's stack
==236312==  in frame #2, created by _dispatch_to_local (threads_tx.c:144)
==236312== 
*** stack smashing detected ***: terminated
==236312== 
==236312== Process terminating with default action of signal 6 (SIGABRT)
==236312==    at 0x493C54C: __pthread_kill_implementation (in /usr/lib64/libc.so.6)
==236312==    by 0x48EFD05: raise (in /usr/lib64/libc.so.6)
==236312==    by 0x48C37F2: abort (in /usr/lib64/libc.so.6)
==236312==    by 0x48C412F: __libc_message.cold (in /usr/lib64/libc.so.6)
==236312==    by 0x49F83BA: __fortify_fail (in /usr/lib64/libc.so.6)
==236312==    by 0x49F8395: __stack_chk_fail (in /usr/lib64/libc.so.6)
==236312==    by 0x487C832: _dispatch_to_local (threads_tx.c:179)
==236312==    by 0x487DD2E: _parse_recv_from_sock (threads_tx.c:634)
==236312==    by 0x487E2C9: _handle_send_to_links (threads_tx.c:737)
==236312==    by 0x487E6C3: _handle_send_to_links_thread (threads_tx.c:833)
==236312==    by 0x493A801: start_thread (in /usr/lib64/libc.so.6)
==236312==    by 0x48DA313: clone (in /usr/lib64/libc.so.6)
==236312== 
==236312== HEAP SUMMARY:
==236312==     in use at exit: 88,308,257 bytes in 1,044 blocks
==236312==   total heap usage: 2,103 allocs, 1,059 frees, 176,634,462 bytes allocated
==236312== 
==236312== LEAK SUMMARY:
==236312==    definitely lost: 0 bytes in 0 blocks
==236312==    indirectly lost: 0 bytes in 0 blocks
==236312==      possibly lost: 1,904 bytes in 7 blocks
==236312==    still reachable: 88,306,353 bytes in 1,037 blocks
==236312==         suppressed: 0 bytes in 0 blocks
==236312== Rerun with --leak-check=full to see details of leaked memory
==236312== 
==236312== Use --track-origins=yes to see where uninitialised values come from
==236312== For lists of detected and suppressed errors, rerun with: -s
==236312== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
Aborted (core dumped)
```

The uninitialised byte error is fixed in first patch.

Second problem is hidden in writev_all. Most problematic part is
```
if (bytes_left >= iov[i].iov_len) {
    bytes_left -= iov[i].iov_len;
    iov++;
    iovcnt--;
    ...
```

This means iov is incremented but iov[i] is still used. Solution would be to use iov[0], but I've decided
to rewrite some part of code to make it simpler and (hopefully) more readable.

Third patch just removed log_printf because it makes log files full of `rx: Adding header to local packet` and hardly usable.

Also how problematic would be to add "scratch" build/make (no rpm, no coverity) check with `--enable-debug` to CI? This is first time I've seen `--enable-debug` discovered some problem (and still don't understand how it is possible this problem was ignored by coverity) on the other hand one extra build is easy so might be worth extra build time.