### PR TITLE
rust tests: Fix extern declaration

### DIFF
--- a/libknet/bindings/rust/tests/src/bin/knet-test.rs
+++ b/libknet/bindings/rust/tests/src/bin/knet-test.rs
@@ -19,7 +19,7 @@ use std::env;
 const CHANNEL: i8 = 1;
 
 // Dirty C function to set the plugin path for testing (only)
-extern {
+extern "C" {
     fn set_plugin_path(knet_h: u64);
 }
 


### PR DESCRIPTION
external API type is required in rust 1.86