### PR TITLE
handle: add flag for skipping route checks

### DIFF
--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -552,7 +552,7 @@ knet_handle_t knet_handle_new(knet_node_id_t host_id,
 		return NULL;
 	}
 
-	if (flags > KNET_HANDLE_FLAG_PRIVILEGED * 2 - 1) {
+	if (flags > KNET_HANDLE_FLAG_ALLOWIFACEMISMATCH * 2 - 1) {
 		errno = EINVAL;
 		return NULL;
 	}

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -90,6 +90,7 @@ typedef uint16_t knet_node_id_t;
  */
 
 #define KNET_HANDLE_FLAG_PRIVILEGED (1ULL << 0)
+#define KNET_HANDLE_FLAG_ALLOWIFACEMISMATCH (1ULL << 1)
 
 /*
  * Flags that affect what appears (and should be provided) on the datafd
@@ -145,6 +146,8 @@ typedef struct knet_handle *knet_handle_t;
  *            communication sockets.  If disabled, failure to acquire large
  *            enough socket buffers is ignored but logged.  Inadequate buffers
  *            lead to poor performance.
+ *   KNET_HANDLE_FLAG_ALLOWIFACEMISMATCH: skip checks for asymmetric routes
+ *            in case they are intentionally part of the network topology
  *
  * @return
  * on success, a new knet_handle_t is returned.

--- a/libknet/transport_udp.c
+++ b/libknet/transport_udp.c
@@ -488,7 +488,7 @@ transport_sock_error_t udp_transport_tx_sock_error(knet_handle_t knet_h, int soc
 static void check_dst_addr_is_valid(knet_handle_t knet_h, int sockfd, struct msghdr *msg)
 {
 #if defined(IP_PKTINFO) || defined(IPV6_PKTINFO)
-        struct cmsghdr *cmsg;
+	struct cmsghdr *cmsg;
 
 	for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
 		int pkt_ifindex = -1;
@@ -551,7 +551,9 @@ transport_rx_isdata_t udp_transport_rx_is_data(knet_handle_t knet_h, int sockfd,
 	if (msg->msg_len == 0)
 		return KNET_TRANSPORT_RX_NOT_DATA_CONTINUE;
 
-	check_dst_addr_is_valid(knet_h, sockfd, &msg->msg_hdr);
+	if ((knet_h->flags & KNET_HANDLE_FLAG_ALLOWIFACEMISMATCH) == 0) {
+		check_dst_addr_is_valid(knet_h, sockfd, &msg->msg_hdr);
+	}
 
 	return KNET_TRANSPORT_RX_IS_DATA;
 }


### PR DESCRIPTION
there are setups in the wild that intentionally have topologies where the ifindex might not match, so add an escape hatch to skip the check if needed.

Closes: #440