### PR TITLE
Allow to configure a dscp value for KNET_LINK_FLAG_TRAFFICHIPRIO

### DIFF
--- a/libknet/handle_api.c
+++ b/libknet/handle_api.c
@@ -472,6 +472,30 @@ int knet_handle_setfwd(knet_handle_t knet_h, unsigned int enabled)
 	return 0;
 }
 
+int knet_handle_setprio_dscp(knet_handle_t knet_h, uint8_t dscp)
+{
+	int savederrno = 0;
+
+	if (!_is_valid_handle(knet_h)) {
+		return -1;
+	}
+
+	savederrno = get_global_wrlock(knet_h);
+	if (savederrno) {
+		log_err(knet_h, KNET_SUB_HANDLE, "Unable to get write lock: %s",
+			strerror(savederrno));
+		errno = savederrno;
+		return -1;
+	}
+
+	knet_h->prio_dscp = dscp;
+
+	pthread_rwlock_unlock(&knet_h->global_rwlock);
+
+	errno = 0;
+	return 0;
+}
+
 int knet_handle_get_stats(knet_handle_t knet_h, struct knet_handle_stats *stats, size_t struct_size)
 {
 	int err = 0, savederrno = 0;

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -197,6 +197,7 @@ struct knet_handle {
 	unsigned int manual_mtu;
 	unsigned int data_mtu;	/* contains the max data size that we can send onwire
 				 * without frags */
+	uint8_t prio_dscp;	/* use this dscp value for KNET_LINK_FLAG_TRAFFICHIPRIO */
 	struct knet_host *host_head;
 	struct knet_host *host_index[KNET_MAX_HOST];
 	knet_transport_t transports[KNET_MAX_TRANSPORTS+1];

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -77,6 +77,7 @@ typedef uint16_t knet_node_id_t;
  * Where possible, set traffic priority to high.
  * On Linux this sets the TOS to INTERACTIVE (6),
  * see tc-prio(8) for more infomation
+ * A dscp value may be configured, see knet_handle_setprio_dscp.
  */
 
 #define KNET_LINK_FLAG_TRAFFICHIPRIO (1ULL << 0)
@@ -575,6 +576,23 @@ int knet_handle_enable_filter(knet_handle_t knet_h,
  */
 
 int knet_handle_setfwd(knet_handle_t knet_h, unsigned int enabled);
+
+/**
+ * knet_handle_setprio_dscp
+ *
+ * @brief Use dscp for IP_TOS on socket to implement KNET_LINK_FLAG_TRAFFICHIPRIO
+ *
+ * knet_h   - pointer to knet_handle_t
+ *
+ * dscp     - dscp value to set on all new sockets
+ *
+ * @return
+ * knet_handle_setfwd returns
+ * 0 on success
+ * -1 on error and errno is set.
+ */
+
+int knet_handle_setprio_dscp(knet_handle_t knet_h, uint8_t dscp);
 
 /**
  * knet_handle_enable_access_lists


### PR DESCRIPTION
We have a corosync + dlm cluster across routers and need to set ip header TOS field to dscp value 40 (CS5) to have the cluster traffic prioritized. We think this maybe useful for others, too.