### PR TITLE
Allow to configure a dscp value for KNET_LINK_FLAG_TRAFFICHIPRIO

### DIFF
--- a/libknet/bindings/rust/src/knet_bindings.rs
+++ b/libknet/bindings/rust/src/knet_bindings.rs
@@ -2596,3 +2596,17 @@ pub fn log_get_loglevel(handle: &Handle, subsystem: SubSystem) -> Result<LogLeve
 	Err(Error::last_os_error())
     }
 }
+
+/// Use dscp for IP_TOS on socket to implement KNET_LINK_FLAG_TRAFFICHIPRIO
+pub fn handle_setprio_dscp(handle: &Handle, dscp: u8) -> Result<()>
+{
+    let res = unsafe {
+	ffi::knet_handle_setprio_dscp(handle.knet_handle as ffi::knet_handle_t,
+				      dscp)
+    };
+    if res == 0 {
+	Ok(())
+    } else {
+	Err(Error::last_os_error())
+    }
+}

--- a/libknet/bindings/rust/tests/src/bin/knet-test.rs
+++ b/libknet/bindings/rust/tests/src/bin/knet-test.rs
@@ -968,6 +968,11 @@ fn main() -> Result<()>
 	return Err(e);
     }
 
+    if let Err(e) = knet::handle_setprio_dscp(&handle1, 1u8) {
+	println!("handle_setprio_dscp failed: {e:?}");
+	return Err(e);
+    }
+
     test_metadata_calls(&handle1, &knet::HostId::new(2))?;
 
     close_handle(&handle1, 2)?;

--- a/libknet/handle_api.c
+++ b/libknet/handle_api.c
@@ -472,6 +472,35 @@ int knet_handle_setfwd(knet_handle_t knet_h, unsigned int enabled)
 	return 0;
 }
 
+int knet_handle_setprio_dscp(knet_handle_t knet_h, uint8_t dscp)
+{
+	int savederrno = 0;
+
+	if (!_is_valid_handle(knet_h)) {
+		return -1;
+	}
+
+	if (dscp > 0x3f) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	savederrno = get_global_wrlock(knet_h);
+	if (savederrno) {
+		log_err(knet_h, KNET_SUB_HANDLE, "Unable to get write lock: %s",
+			strerror(savederrno));
+		errno = savederrno;
+		return -1;
+	}
+
+	knet_h->prio_dscp = dscp;
+
+	pthread_rwlock_unlock(&knet_h->global_rwlock);
+
+	errno = 0;
+	return 0;
+}
+
 int knet_handle_get_stats(knet_handle_t knet_h, struct knet_handle_stats *stats, size_t struct_size)
 {
 	int err = 0, savederrno = 0;

--- a/libknet/internals.h
+++ b/libknet/internals.h
@@ -197,6 +197,7 @@ struct knet_handle {
 	unsigned int manual_mtu;
 	unsigned int data_mtu;	/* contains the max data size that we can send onwire
 				 * without frags */
+	uint8_t prio_dscp;	/* use this dscp value for KNET_LINK_FLAG_TRAFFICHIPRIO */
 	struct knet_host *host_head;
 	struct knet_host *host_index[KNET_MAX_HOST];
 	knet_transport_t transports[KNET_MAX_TRANSPORTS+1];

--- a/libknet/libknet.h
+++ b/libknet/libknet.h
@@ -77,6 +77,7 @@ typedef uint16_t knet_node_id_t;
  * Where possible, set traffic priority to high.
  * On Linux this sets the TOS to INTERACTIVE (6),
  * see tc-prio(8) for more infomation
+ * A dscp value may be configured, see knet_handle_setprio_dscp.
  */
 
 #define KNET_LINK_FLAG_TRAFFICHIPRIO (1ULL << 0)
@@ -575,6 +576,30 @@ int knet_handle_enable_filter(knet_handle_t knet_h,
  */
 
 int knet_handle_setfwd(knet_handle_t knet_h, unsigned int enabled);
+
+/**
+ * knet_handle_setprio_dscp
+ *
+ * @brief Use dscp for IP_TOS on socket to implement KNET_LINK_FLAG_TRAFFICHIPRIO
+ *
+ * knet_h   - pointer to knet_handle_t
+ *
+ * dscp     - dscp value to set on all new sockets
+ *
+ * This function must be called prior to configure knet links.
+ *
+ * It disables the use of IPTOS_LOWDELAY and uses the given dscp value in the
+ * IP header's TOS field instead.
+ *
+ * Setting dscp to 0 reverts to using IPTOS_LOWDELAY.
+ *
+ * @return
+ * knet_handle_setprio_dscp returns
+ * 0 on success
+ * -1 on error and errno is set.
+ */
+
+int knet_handle_setprio_dscp(knet_handle_t knet_h, uint8_t dscp);
 
 /**
  * knet_handle_enable_access_lists

--- a/libknet/tests/api-check.mk
+++ b/libknet/tests/api-check.mk
@@ -83,7 +83,8 @@ api_checks		= \
 			  api_knet_handle_get_onwire_ver_test \
 			  api_knet_handle_set_onwire_ver_test \
 			  api_knet_handle_get_host_defrag_bufs_test \
-			  api_knet_handle_set_host_defrag_bufs_test
+			  api_knet_handle_set_host_defrag_bufs_test \
+			  api_knet_handle_setprio_dscp_test
 
 api_knet_handle_new_test_SOURCES = api_knet_handle_new.c \
 				   test-common.c
@@ -316,3 +317,5 @@ api_knet_handle_get_host_defrag_bufs_test_SOURCES = api_knet_handle_get_host_def
 
 api_knet_handle_set_host_defrag_bufs_test_SOURCES = api_knet_handle_set_host_defrag_bufs.c \
 						    test-common.c
+api_knet_handle_setprio_dscp_test_SOURCES = api_knet_handle_setprio_dscp.c \
+					     test-common.c

--- a/libknet/tests/api_knet_handle_setprio_dscp.c
+++ b/libknet/tests/api_knet_handle_setprio_dscp.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016-2025 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: David Hanisch <hanisch@strato.de>
+ *
+ * This software licensed under GPL-2.0+
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "libknet.h"
+
+#include "internals.h"
+#include "test-common.h"
+
+static void test(void)
+{
+	knet_handle_t knet_h1, knet_h[2];
+	int res;
+	int logfds[2];
+
+	printf("Test knet_handle_setprio_dscp incorrect knet_h\n");
+
+	if ((!knet_handle_setprio_dscp(NULL, 1)) || (errno != EINVAL)) {
+		printf("knet_handle_setprio_dscp accepted invalid knet_h or returned incorrect error: %s\n", strerror(errno));
+		exit(FAIL);
+	}
+
+	setup_logpipes(logfds);
+
+	knet_h1 = knet_handle_start(logfds, KNET_LOG_DEBUG, knet_h);
+
+	flush_logs(logfds[0], stdout);
+
+	printf("Test knet_handle_setprio_dscp with 100 (incorrect)\n");
+	FAIL_ON_SUCCESS(knet_handle_setprio_dscp(knet_h1, 100), EINVAL);
+
+	printf("Test knet_handle_setprio_dscp with 40 (correct)\n");
+	FAIL_ON_ERR(knet_handle_setprio_dscp(knet_h1, 40));
+
+	if (knet_h1->prio_dscp != 40) {
+		printf("knet_handle_setprio_dscp failed to set the value\n");
+		CLEAN_EXIT(FAIL);
+	}
+	CLEAN_EXIT(CONTINUE);
+}
+
+int main(int argc, char *argv[])
+{
+	test();
+
+	return PASS;
+}

--- a/libknet/transport_common.c
+++ b/libknet/transport_common.c
@@ -166,7 +166,6 @@ static int _configure_sockbuf(knet_handle_t knet_h, int sock, int option, int fo
 int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, const char *type)
 {
 	int err = 0, savederrno = 0;
-	int value;
 
 	if (_fdset_cloexec(sock)) {
 		savederrno = errno;
@@ -203,7 +202,8 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 	if (flags & KNET_LINK_FLAG_TRAFFICHIPRIO) {
 #ifdef KNET_LINUX
 #ifdef SO_PRIORITY
-		value = 6; /* TC_PRIO_INTERACTIVE */
+		int value = 6; /* TC_PRIO_INTERACTIVE */
+
 		if (setsockopt(sock, SOL_SOCKET, SO_PRIORITY, &value, sizeof(value)) < 0) {
 			savederrno = errno;
 			err = -1;
@@ -216,18 +216,35 @@ int _configure_common_socket(knet_handle_t knet_h, int sock, uint64_t flags, con
 		log_debug(knet_h, KNET_SUB_TRANSPORT, "TC_PRIO_INTERACTIVE not available in this build/platform");
 #endif
 #endif
-#if defined(IP_TOS) && defined(IPTOS_LOWDELAY)
-		value = IPTOS_LOWDELAY;
-		if (setsockopt(sock, IPPROTO_IP, IP_TOS, &value, sizeof(value)) < 0) {
-			savederrno = errno;
-			err = -1;
-			log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s priority: %s",
-				type, strerror(savederrno));
-			goto exit_error;
-		}
-		log_debug(knet_h, KNET_SUB_TRANSPORT, "IPTOS_LOWDELAY enabled on socket: %i", sock);
+#if defined(IP_TOS)
+		if (knet_h->prio_dscp) {
+			/* dscp is the 6 highest bits of TOS IP header field, RFC 2474 */
+			int value = (knet_h->prio_dscp & 0x3f) << 2;
+
+			if (setsockopt(sock, IPPROTO_IP, IP_TOS, &value, sizeof(value)) < 0) {
+				savederrno = errno;
+				err = -1;
+				log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s priority: %s",
+					type, strerror(savederrno));
+				goto exit_error;
+			}
+			log_debug(knet_h, KNET_SUB_TRANSPORT, "dscp %d set on socket: %i", knet_h->prio_dscp, sock);
+		} else {
+#if defined(IPTOS_LOWDELAY)
+			int value = IPTOS_LOWDELAY;
+
+			if (setsockopt(sock, IPPROTO_IP, IP_TOS, &value, sizeof(value)) < 0) {
+				savederrno = errno;
+				err = -1;
+				log_err(knet_h, KNET_SUB_TRANSPORT, "Unable to set %s priority: %s",
+					type, strerror(savederrno));
+				goto exit_error;
+			}
+			log_debug(knet_h, KNET_SUB_TRANSPORT, "IPTOS_LOWDELAY enabled on socket: %i", sock);
 #else
-		log_debug(knet_h, KNET_SUB_TRANSPORT, "IPTOS_LOWDELAY not available in this build/platform");
+			log_debug(knet_h, KNET_SUB_TRANSPORT, "IPTOS_LOWDELAY not available in this build/platform");
+#endif
+		}
 #endif
 	}
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -90,7 +90,8 @@ knet_man3_MANS = \
 		knet_handle_get_onwire_ver.3 \
 		knet_handle_set_onwire_ver.3 \
 		knet_handle_get_host_defrag_bufs.3 \
-		knet_handle_set_host_defrag_bufs.3
+		knet_handle_set_host_defrag_bufs.3 \
+		knet_handle_setprio_dscp.3
 
 if BUILD_LIBNOZZLE
 nozzle_man3_MANS = \


### PR DESCRIPTION
Currently IPTOS_LOWDELAY is used for IP_TOS. A setup may require to set a certain dscp value to prioritize the IP traffic.

This is the same as https://github.com/kronosnet/kronosnet/pull/452 with the comments incorporated.

I did not want to create a new pull request, may fault, I did not expect a force push would close the old one. Next time I'll do better.
