### PR TITLE
libnozzle - Fix FreeBSD nozzle_down

### DIFF
--- a/libnozzle/libnozzle.c
+++ b/libnozzle/libnozzle.c
@@ -113,6 +113,7 @@ static void destroy_iface(nozzle_t nozzle)
 	memmove(ifname, nozzle->name, IFNAMSIZ);
 
 	ioctl(lib_cfg.ioctlfd, SIOCIFDESTROY, &ifr);
+	ioctl(lib_cfg.ioctlfd, SIOCGIFFLAGS, &ifr);
 #endif
 
 	free(nozzle);


### PR DESCRIPTION
For reasons I am unlikely ever to understand, it's necessary to call SIOCGIFFLAGS on a tap interface after SIOCIFDSTROY for the device to actually be removed.

...so do that