### PR TITLE
libnozzle - Fix FreeBSD nozzle_down (take 2)

### DIFF
--- a/libnozzle/libnozzle.c
+++ b/libnozzle/libnozzle.c
@@ -491,23 +491,7 @@ nozzle_t nozzle_open(char *devname, size_t devname_size, const char *updownpath)
 
 #ifdef KNET_BSD
 	if (!strlen(devname)) {
-		/*
-		 * FreeBSD 13 kernel has changed how the tap module
-		 * works and tap0 cannot be removed from the system.
-		 * This means that tap0 settings are never reset to default
-		 * and nozzle cannot control the default state of the device
-		 * when taking over.
-		 * nozzle expects some parameters to be default when opening
-		 * a tap device (such as random mac address, default MTU, no
-		 * other attributes, etc.)
-		 *
-		 * For 13 and higher, simply skip tap0 as usable device.
-		 */
-#if __FreeBSD__ >= 13
-		for (i = 1; i < 256; i++) {
-#else
 		for (i = 0; i < 256; i++) {
-#endif
 			memset(&ifr, 0, sizeof(struct ifreq));
 
 			snprintf(curnozzle, sizeof(curnozzle) - 1, "tap%u", i);
@@ -525,6 +509,7 @@ nozzle_t nozzle_open(char *devname, size_t devname_size, const char *updownpath)
 			/* For some reason we can't open that device, keep trying
 			   but don't leave debris */
 			(void)ioctl(lib_cfg.ioctlfd, SIOCIFDESTROY, &ifr);
+			(void)ioctl(lib_cfg.ioctlfd, SIOCGIFFLAGS, &ifr);
 		}
 		snprintf(curnozzle, sizeof(curnozzle) -1 , "tap%u", i);
 	} else {

--- a/libnozzle/tests/test-common.c
+++ b/libnozzle/tests/test-common.c
@@ -65,6 +65,7 @@ void need_tun(void)
 	close(fd);
 #ifdef KNET_BSD
 	ioctl(ioctlfd, SIOCIFDESTROY, &ifr);
+	ioctl(ioctlfd, SIOCGIFFLAGS, &ifr);
 	close(ioctlfd);
 #endif
 }


### PR DESCRIPTION
also, FreeBSD 13+ now allow tap0 to be delete.. if only the kernel interface was stable....