### PR TITLE
Distribute STYLE_GUIDE.md and m4/pkg_check_var.m4

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,8 @@ TARGZFILE		= $(PACKAGE_NAME)-$(VERSION).tar.gz
 
 EXTRA_DIST		= autogen.sh .version \
 			  NOTES_TO_PACKAGE_MAINTAINERS \
+			  STYLE_GUIDE.md \
+			  m4/pkg_check_var.m4 \
 			  $(SPEC).in build-aux
 
 SUBDIRS			= libnozzle libknet


### PR DESCRIPTION
For sake of completeness, mostly, since almost everybody uses Git and pkg-config>=0.28 or pkgconf (where PKG_CHECK_VAR is already included) for development nowadays.