### PR TITLE
tests: Remove discards const qualifier warnings

### DIFF
--- a/libknet/tests/int_links_acl_ip.c
+++ b/libknet/tests/int_links_acl_ip.c
@@ -49,7 +49,7 @@ static int get_ipaddress(const char *buf, struct sockaddr_storage *addr)
 static int read_2ip(const char *buf, const char *delim, struct sockaddr_storage *addr, struct sockaddr_storage *addr2)
 {
 	char tmpbuf[BUFLEN];
-	char *deli;
+	const char *deli;
 
 	deli = strstr(buf, delim);
 	if (!deli) {


### PR DESCRIPTION
gcc 15.2.1 started producing warning about "assignment discards ‘const’ qualifier from pointer target type" so patch adds const qualifier to fix this warning.