### PR TITLE
handle.c:Add unique names to handle threads

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,6 +259,8 @@ AM_CONDITIONAL([BUILD_FOR_SOLARIS], [test "x$build_for_solaris" = "xyes"])
 # Checks for header files.
 AC_CHECK_HEADERS([sys/epoll.h])
 AC_CHECK_FUNCS([kevent])
+# Check for pthread_setname_np (glibc extension on Linux)
+AC_CHECK_FUNCS([pthread_setname_np])
 # if neither sys/epoll.h nor kevent are present, we should fail.
 
 if test "x$ac_cv_header_sys_epoll_h" = xno && test "x$ac_cv_func_kevent" = xno; then

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -443,6 +443,7 @@ static int _start_threads(knet_handle_t knet_h)
 			strerror(savederrno));
 		goto exit_fail;
 	}
+	knet_thread_setname(knet_h->pmtud_link_handler_thread, "knet-pmtud");
 
 	set_thread_status(knet_h, KNET_THREAD_DST_LINK, KNET_THREAD_REGISTERED);
 	savederrno = pthread_create(&knet_h->dst_link_handler_thread, &attr,
@@ -452,6 +453,7 @@ static int _start_threads(knet_handle_t knet_h)
 			strerror(savederrno));
 		goto exit_fail;
 	}
+	knet_thread_setname(knet_h->dst_link_handler_thread, "knet-dstcache");
 
 	set_thread_status(knet_h, KNET_THREAD_TX, KNET_THREAD_REGISTERED);
 	savederrno = pthread_create(&knet_h->send_to_links_thread, &attr,
@@ -461,6 +463,7 @@ static int _start_threads(knet_handle_t knet_h)
 			strerror(savederrno));
 		goto exit_fail;
 	}
+	knet_thread_setname(knet_h->send_to_links_thread, "knet-tx");
 
 	set_thread_status(knet_h, KNET_THREAD_RX, KNET_THREAD_REGISTERED);
 	savederrno = pthread_create(&knet_h->recv_from_links_thread, &attr,
@@ -470,6 +473,7 @@ static int _start_threads(knet_handle_t knet_h)
 			strerror(savederrno));
 		goto exit_fail;
 	}
+	knet_thread_setname(knet_h->recv_from_links_thread, "knet-rx");
 
 	set_thread_status(knet_h, KNET_THREAD_HB, KNET_THREAD_REGISTERED);
 	savederrno = pthread_create(&knet_h->heartbt_thread, &attr,
@@ -479,7 +483,8 @@ static int _start_threads(knet_handle_t knet_h)
 			strerror(savederrno));
 		goto exit_fail;
 	}
-
+	knet_thread_setname(knet_h->heartbt_thread, "knet-heartbt");
+	
 	savederrno = pthread_attr_destroy(&attr);
 	if (savederrno) {
 		log_err(knet_h, KNET_SUB_HANDLE, "Unable to destroy pthread attributes: %s",

--- a/libknet/threads_common.h
+++ b/libknet/threads_common.h
@@ -10,6 +10,17 @@
 #ifndef __KNET_THREADS_COMMON_H__
 #define __KNET_THREADS_COMMON_H__
 
+#include "config.h"
+
+#include <pthread.h>
+
+#ifdef HAVE_PTHREAD_SETNAME_NP
+#define knet_thread_setname(tid, name) pthread_setname_np((tid), (name))
+#else
+#define knet_thread_setname(tid, name) ((void)0)
+#endif
+
+
 #include "internals.h"
 
 #define KNET_THREAD_UNREGISTERED	0 /* thread does not exist */


### PR DESCRIPTION
Assign unique names to every thread spawned within the codebase.
This enhances observability for debugging and monitoring workflows (visible via utilities such as ps, top, and pidstat).
Supporting example paragraph:
For instance, when inspecting the corosync process using pidstat, all its worker threads uniformly display the generic name corosync, making it impossible to differentiate individual threads. After assigning dedicated thread names, operators can quickly pinpoint which specific thread is responsible for abnormal behavior.