### PR TITLE
build: add CLAUDE.md to release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ TARGZFILE		= $(PACKAGE_NAME)-$(VERSION).tar.gz
 EXTRA_DIST		= autogen.sh .version \
 			  NOTES_TO_PACKAGE_MAINTAINERS \
 			  STYLE_GUIDE.md \
+			  CLAUDE.md \
 			  m4/pkg_check_var.m4 \
 			  $(SPEC).in build-aux
 


### PR DESCRIPTION
## Summary

Add CLAUDE.md to EXTRA_DIST in Makefile.am so it's included in release tarballs.

CLAUDE.md provides AI-assisted development documentation and should be distributed with releases for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)