### PR TITLE
nozzle: Introduce test macros similar to libknet

### DIFF
--- a/libnozzle/tests/api_nozzle_prefix_validation.c
+++ b/libnozzle/tests/api_nozzle_prefix_validation.c
@@ -9,7 +9,6 @@
 #include "config.h"
 
 #include <errno.h>
-#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,167 +36,50 @@
  * - Verify valid prefix works correctly
  */
 
-static void test_prefix_validation(void)
+static int test(void)
 {
 	char device_name[IFNAMSIZ];
 	size_t size = IFNAMSIZ;
-	nozzle_t nozzle;
-	int err;
+	int err = 0;
+	nozzle_t nozzle = NULL;
 
-	printf("Test: Prefix validation\n\n");
-
-	printf("Step 1: Create nozzle device\n");
+	printf("Testing prefix validation\n");
 
 	memset(device_name, 0, size);
-	nozzle = nozzle_open(device_name, size, NULL);
-	if (!nozzle) {
-		printf("SKIP: Unable to create nozzle device (requires root/CAP_NET_ADMIN)\n");
-		printf("      This is expected when not running as root.\n");
-		exit(SKIP);
-	}
 
-	printf("Created nozzle device: %s\n\n", device_name);
+	printf("Creating nozzle interface\n");
+	FAIL_ON_NULL(nozzle, nozzle_open(device_name, size, NULL));
 
-	/*
-	 * Test Case 1: Prefix = "0" (invalid, too small)
-	 */
-	printf("Step 2: Test invalid prefix \"0\" (should fail)\n");
+	printf("Testing invalid prefix \"0\"\n");
+	FAIL_ON_SUCCESS(nozzle_add_ip(nozzle, "192.168.1.1", "0"), EINVAL);
 
-	err = nozzle_add_ip(nozzle, "192.168.1.1", "0");
-	if (err == 0) {
-		printf("FAIL: nozzle_add_ip() accepted prefix \"0\" (should reject)\n");
-		printf("      This would configure /0 netmask (security risk)\n");
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-	if (errno != EINVAL) {
-		printf("FAIL: Expected errno EINVAL, got %d (%s)\n", errno, strerror(errno));
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
+	printf("Testing invalid prefix \"-1\"\n");
+	FAIL_ON_SUCCESS(nozzle_add_ip(nozzle, "192.168.1.1", "-1"), EINVAL);
 
-	printf("Correctly rejected prefix \"0\" with EINVAL\n\n");
+	printf("Testing invalid IPv4 prefix \"33\"\n");
+	FAIL_ON_SUCCESS(nozzle_add_ip(nozzle, "192.168.1.1", "33"), EINVAL);
 
-	/*
-	 * Test Case 2: Prefix = "-1" (invalid, negative)
-	 */
-	printf("Step 3: Test invalid prefix \"-1\" (should fail)\n");
+	printf("Testing invalid IPv6 prefix \"129\"\n");
+	FAIL_ON_SUCCESS(nozzle_add_ip(nozzle, "::1", "129"), EINVAL);
 
-	err = nozzle_add_ip(nozzle, "192.168.1.1", "-1");
-	if (err == 0) {
-		printf("FAIL: nozzle_add_ip() accepted prefix \"-1\" (should reject)\n");
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-	if (errno != EINVAL) {
-		printf("FAIL: Expected errno EINVAL, got %d (%s)\n", errno, strerror(errno));
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
+	printf("Testing invalid prefix \"invalid\"\n");
+	FAIL_ON_SUCCESS(nozzle_add_ip(nozzle, "192.168.1.1", "invalid"), EINVAL);
 
-	printf("Correctly rejected prefix \"-1\" with EINVAL\n\n");
+	printf("Testing valid IPv4 prefix \"24\"\n");
+	FAIL_ON_ERR(nozzle_add_ip(nozzle, "192.168.1.1", "24"));
 
-	/*
-	 * Test Case 3: Prefix = "33" for IPv4 (invalid, too large)
-	 */
-	printf("Step 4: Test invalid IPv4 prefix \"33\" (should fail, max is 32)\n");
+	printf("Cleaning up IPv4 address\n");
+	FAIL_ON_ERR(nozzle_del_ip(nozzle, "192.168.1.1", "24"));
 
-	err = nozzle_add_ip(nozzle, "192.168.1.1", "33");
-	if (err == 0) {
-		printf("FAIL: nozzle_add_ip() accepted IPv4 prefix \"33\" (should reject)\n");
-		printf("      IPv4 prefix must be <= 32\n");
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-	if (errno != EINVAL) {
-		printf("FAIL: Expected errno EINVAL, got %d (%s)\n", errno, strerror(errno));
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-
-	printf("Correctly rejected IPv4 prefix \"33\" with EINVAL\n\n");
-
-	/*
-	 * Test Case 4: Prefix = "129" for IPv6 (invalid, too large)
-	 */
-	printf("Step 5: Test invalid IPv6 prefix \"129\" (should fail, max is 128)\n");
-
-	err = nozzle_add_ip(nozzle, "::1", "129");
-	if (err == 0) {
-		printf("FAIL: nozzle_add_ip() accepted IPv6 prefix \"129\" (should reject)\n");
-		printf("      IPv6 prefix must be <= 128\n");
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-	if (errno != EINVAL) {
-		printf("FAIL: Expected errno EINVAL, got %d (%s)\n", errno, strerror(errno));
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-
-	printf("Correctly rejected IPv6 prefix \"129\" with EINVAL\n\n");
-
-	/*
-	 * Test Case 5: Prefix = "invalid" (non-numeric, atoi() returns 0)
-	 */
-	printf("Step 6: Test invalid prefix \"invalid\" (should fail)\n");
-	printf("        This tests the original vulnerability where atoi() returns 0\n");
-
-	err = nozzle_add_ip(nozzle, "192.168.1.1", "invalid");
-	if (err == 0) {
-		printf("FAIL: nozzle_add_ip() accepted prefix \"invalid\" (should reject)\n");
-		printf("      This is the original Prefix validation vulnerability!\n");
-		printf("      atoi(\"invalid\") returns 0, would configure /0 netmask\n");
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-	if (errno != EINVAL) {
-		printf("FAIL: Expected errno EINVAL, got %d (%s)\n", errno, strerror(errno));
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-
-	printf("Correctly rejected prefix \"invalid\" with EINVAL\n");
-	printf("Prefix validation vulnerability is FIXED (atoi(\"invalid\") = 0 now rejected)\n\n");
-
-	/*
-	 * Test Case 6: Valid prefix should still work
-	 */
-	printf("Step 7: Test valid prefix \"24\" (should succeed)\n");
-
-	err = nozzle_add_ip(nozzle, "192.168.1.1", "24");
-	if (err != 0) {
-		printf("FAIL: nozzle_add_ip() rejected valid prefix \"24\": %s\n", strerror(errno));
-		printf("      Validation is too strict - valid prefixes should work\n");
-		nozzle_close(nozzle);
-		exit(FAIL);
-	}
-
-	printf("Correctly accepted valid prefix \"24\"\n\n");
-
-	/* Clean up the IP we just added */
-	err = nozzle_del_ip(nozzle, "192.168.1.1", "24");
-	if (err != 0) {
-		printf("WARNING: Failed to clean up IP 192.168.1.1/24: %s\n", strerror(errno));
-	}
-
-	/*
-	 * Test Case 7: Valid IPv6 prefix should work (if IPv6 is available)
-	 */
-	printf("Step 8: Test valid IPv6 prefix \"64\" (should succeed if IPv6 available)\n");
-
+	printf("Testing valid IPv6 prefix \"64\"\n");
 	err = nozzle_add_ip(nozzle, "fd00::1", "64");
-	if (err != 0) {
-		/* IPv6 might not be available on this system, which is OK */
+	if (err) {
 		printf("WARNING: Could not add IPv6 address (IPv6 may not be available): %s\n", strerror(errno));
-		printf("  This is not a test failure - IPv6 validation is tested via invalid prefixes\n\n");
+		printf("Skipping IPv6 positive test\n");
+		err = 0;
 	} else {
-		printf("Correctly accepted valid IPv6 prefix \"64\"\n\n");
-		/* Clean up */
-		err = nozzle_del_ip(nozzle, "fd00::1", "64");
-		if (err != 0) {
-			printf("WARNING: Failed to clean up IP fd00::1/64: %s\n", strerror(errno));
-		}
+		printf("Cleaning up IPv6 address\n");
+		FAIL_ON_ERR(nozzle_del_ip(nozzle, "fd00::1", "64"));
 	}
 
 	printf("=== Prefix validation test PASSED ===\n");
@@ -212,12 +94,21 @@ static void test_prefix_validation(void)
 	printf("All validation checks return EINVAL\n");
 	printf("Network misconfiguration prevented\n\n");
 
-	nozzle_close(nozzle);
+out_clean:
+	if (nozzle) {
+		nozzle_close(nozzle);
+	}
+
+	return err;
 }
 
 int main(void)
 {
-	test_prefix_validation();
+	need_root();
+	need_tun();
+
+	if (test() < 0)
+		return FAIL;
 
 	return PASS;
 }


### PR DESCRIPTION
Add comprehensive test macros to test-common.h, similar to those used in libknet tests:
- FAIL_ON_ERR: Fail if function returns error
- FAIL_ON_SUCCESS: Negative test - expect failure with specific errno
- FAIL_ON_NULL/FAIL_ON_NOT_NULL: For pointer-returning functions
- FAIL_ON_NONZERO/FAIL_ON_ZERO: For comparisons
- FAIL_ON_ERR_ONLY: For functions returning -1 on error
- FAIL_ON_CMD: For execute_bin_sh_command and similar
- FAIL_ON_CMD_SUCCESS: Negative test for commands

These macros:
- Reduce code duplication and improve readability
- Print descriptive failure messages with line numbers
- Handle errno correctly for debugging
- Automatically clean up via 'goto out_clean' pattern

All test files have been converted to use these macros, significantly reducing test code size (from 1280 to ~600 lines net) while improving clarity and error reporting.

Also fixed Solaris-specific test issues where interface state checks aren't possible - these now skip the check rather than fail.