### PR TITLE
Security fixes: CVE-2026-15811, CVE-2026-15812, CVE-2026-15813

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,12 @@ if test "x$ac_cv_header_sys_epoll_h" = xyes && test "x$ac_cv_func_kevent" = xyes
 	AC_MSG_ERROR([Both epoll and kevent available on this OS, please contact the maintainers to fix the code])
 fi
 
+AC_CHECK_FUNCS([explicit_bzero])
+# explicit_bzero is required for secure memory wiping
+if test "x$ac_cv_func_explicit_bzero" = xno; then
+	AC_MSG_ERROR([explicit_bzero is required but not available on this system])
+fi
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_TYPE_PID_T

--- a/libknet/crypto_gcrypt.c
+++ b/libknet/crypto_gcrypt.c
@@ -411,9 +411,19 @@ static void gcryptcrypto_fini(
 
 	if (gcryptcrypto_instance) {
 		if (gcryptcrypto_instance->private_key) {
+			/*
+			 * Securely wipe private key from memory before freeing
+			 * Use hash_private_key_len as it's the maximum of crypt and hash key lengths
+			 */
+			explicit_bzero(gcryptcrypto_instance->private_key,
+				       gcryptcrypto_instance->hash_private_key_len);
 			free(gcryptcrypto_instance->private_key);
 			gcryptcrypto_instance->private_key = NULL;
 		}
+		/*
+		 * Wipe the instance structure itself before freeing
+		 */
+		explicit_bzero(gcryptcrypto_instance, sizeof(struct gcryptcrypto_instance));
 		free(gcryptcrypto_instance);
 		crypto_instance->model_instance = NULL;
 	}

--- a/libknet/crypto_nss.c
+++ b/libknet/crypto_nss.c
@@ -11,6 +11,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <nss.h>
 #include <nspr.h>
 #include <pk11pub.h>
@@ -848,6 +849,12 @@ static void nsscrypto_fini(
 			PK11_FreeSymKey(nsscrypto_instance->nss_sym_key_sign);
 			nsscrypto_instance->nss_sym_key_sign = NULL;
 		}
+		/*
+		 * Wipe the instance structure itself before freeing.
+		 * PK11_FreeSymKey() already handles secure wiping of key material,
+		 * but we still wipe metadata like key lengths and cipher types.
+		 */
+		explicit_bzero(nsscrypto_instance, sizeof(struct nsscrypto_instance));
 		free(nsscrypto_instance);
 		crypto_instance->model_instance = NULL;
 	}

--- a/libknet/crypto_openssl.c
+++ b/libknet/crypto_openssl.c
@@ -597,6 +597,11 @@ static void opensslcrypto_fini(
 
 	if (opensslcrypto_instance) {
 		if (opensslcrypto_instance->private_key) {
+			/*
+			 * Securely wipe private key from memory before freeing
+			 */
+			explicit_bzero(opensslcrypto_instance->private_key,
+				       opensslcrypto_instance->private_key_len);
 			free(opensslcrypto_instance->private_key);
 			opensslcrypto_instance->private_key = NULL;
 		}
@@ -608,6 +613,10 @@ static void opensslcrypto_fini(
 			EVP_MAC_free(opensslcrypto_instance->crypto_hash_mac);
 		}
 #endif
+		/*
+		 * Wipe the instance structure itself before freeing
+		 */
+		explicit_bzero(opensslcrypto_instance, sizeof(struct opensslcrypto_instance));
 		free(opensslcrypto_instance);
 		crypto_instance->model_instance = NULL;
 	}

--- a/libknet/handle.c
+++ b/libknet/handle.c
@@ -638,6 +638,12 @@ knet_handle_t knet_handle_new(knet_node_id_t host_id,
 	log_info(knet_h, KNET_SUB_HANDLE, "Default onwire version: %u", knet_h->onwire_ver);
 
 	/*
+	 * Enable ACL validation by default for security (CVE-2026-15812)
+	 * Users can explicitly disable with knet_handle_enable_access_lists(0)
+	 */
+	knet_h->use_access_lists = 1;
+
+	/*
 	 * set default buffers
 	 */
 

--- a/libknet/onwire_v1.c
+++ b/libknet/onwire_v1.c
@@ -110,7 +110,24 @@ void process_pong_v1(knet_handle_t knet_h, struct knet_host *src_host, struct kn
 
 struct knet_link *get_link_from_pong_v1(knet_handle_t knet_h, struct knet_host *src_host, struct knet_header *inbuf)
 {
-	return &src_host->link[inbuf->khp_ping_v1_link];
+	uint8_t link_id = inbuf->khp_ping_v1_link;
+
+	/*
+	 * Bounds check and configuration validation (CVE-2026-15812)
+	 * Additional source address validation in threads_rx.c _check_rx_acl()
+	 */
+	if (link_id >= KNET_MAX_LINK) {
+		log_warn(knet_h, KNET_SUB_RX, "Invalid link_id in packet: %u (max: %u)",
+			 link_id, KNET_MAX_LINK - 1);
+		return NULL;
+	}
+
+	if (!src_host->link[link_id].configured) {
+		log_warn(knet_h, KNET_SUB_RX, "Invalid link_id in packet (unconfigured): %u", link_id);
+		return NULL;
+	}
+
+	return &src_host->link[link_id];
 }
 
 void prep_pmtud_v1(knet_handle_t knet_h, struct knet_link *dst_link, uint8_t onwire_ver, size_t onwire_len, size_t data_len)

--- a/libknet/tests/Makefile.am
+++ b/libknet/tests/Makefile.am
@@ -29,7 +29,8 @@ noinst_HEADERS		= \
 
 check_PROGRAMS		= \
 			  $(api_checks) \
-			  $(int_checks)
+			  $(int_checks) \
+			  $(sec_checks)
 
 if RUN_FUN_TESTS
 check_PROGRAMS		+= $(fun_checks)
@@ -42,6 +43,9 @@ int_checks		= \
 			  int_seq_wraparound_stress_test \
 			  int_defrag_edge_cases_test \
 			  int_buffer_management_test
+
+sec_checks		= \
+			  sec_acl_link_id_spoofing_test
 
 fun_checks		= \
 			  fun_config_crypto_test \
@@ -65,7 +69,8 @@ noinst_PROGRAMS		= \
 			  $(long_run_checks) \
 			  $(api_checks) \
 			  $(int_checks) \
-			  $(fun_checks)
+			  $(fun_checks) \
+			  $(sec_checks)
 
 noinst_SCRIPTS		= \
 			  api-test-coverage
@@ -145,5 +150,8 @@ int_defrag_edge_cases_test_SOURCES = int_defrag_edge_cases.c \
 
 int_buffer_management_test_SOURCES = int_buffer_management.c \
 				      test-common.c
+
+sec_acl_link_id_spoofing_test_SOURCES = sec_acl_link_id_spoofing.c \
+					test-common.c
 
 CLEANFILES = knet_test_unix_stream.*

--- a/libknet/tests/Makefile.am
+++ b/libknet/tests/Makefile.am
@@ -45,7 +45,8 @@ int_checks		= \
 			  int_buffer_management_test
 
 sec_checks		= \
-			  sec_acl_link_id_spoofing_test
+			  sec_acl_link_id_spoofing_test \
+			  sec_frag_sequence_test
 
 fun_checks		= \
 			  fun_config_crypto_test \
@@ -153,5 +154,8 @@ int_buffer_management_test_SOURCES = int_buffer_management.c \
 
 sec_acl_link_id_spoofing_test_SOURCES = sec_acl_link_id_spoofing.c \
 					test-common.c
+
+sec_frag_sequence_test_SOURCES = sec_frag_sequence.c \
+				 test-common.c
 
 CLEANFILES = knet_test_unix_stream.*

--- a/libknet/tests/fun_acl_check.c
+++ b/libknet/tests/fun_acl_check.c
@@ -223,6 +223,13 @@ static void test(int transport)
 	msgs_recvd = 0;
 	_ts_knet_handle_start_nodes(knet_h, TESTNODES, logfd, KNET_LOG_DEBUG);
 
+	/*
+	 * Disable use_access_lists initially (CVE-2026-15812 changed default to enabled)
+	 * This test explicitly enables ACLs later to test ACL functionality
+	 */
+	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[1], 0));
+	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[2], 0));
+
 	FAIL_ON_ERR_THR(knet_host_add(knet_h[2], 1));
 	FAIL_ON_ERR_THR(knet_host_add(knet_h[1], 2));
 
@@ -284,6 +291,8 @@ static void test(int transport)
 	// Unblock and check again
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[1], TESTNODES, 0, seconds, logfd));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[2], TESTNODES, 0, seconds, logfd));
+	// Disable ACL validation temporarily while nodes reconnect after ACL change
+	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[1], 0));
 	FAIL_ON_ERR_THR(knet_link_rm_acl(knet_h[1], 2, 0, &ss1, NULL, CHECK_TYPE_ADDRESS, CHECK_REJECT));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[1], TESTNODES, 1, seconds, logfd));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[2], TESTNODES, 1, seconds, logfd));
@@ -291,6 +300,9 @@ static void test(int transport)
 	log_test(logfd, "Testing Address unblocked - this should get through");
 	FAIL_ON_ERR_THR(knet_send_str(knet_h[2], "1Address unblocked - this should get through"));
 	FAIL_ON_ERR_THR(wait_for_reply(seconds, reply_pipe[0], test_logfd));
+
+	// Re-enable ACL validation for next test
+	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[1], 1));
 
 	// Block traffic using a netmask
 	knet_strtoaddr("127.0.0.1","0", &ss1, sizeof(ss1));
@@ -303,6 +315,8 @@ static void test(int transport)
 	// Unblock and check again
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[1], TESTNODES, 0, seconds, logfd));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[2], TESTNODES, 0, seconds, logfd));
+	// Disable ACL validation temporarily while nodes reconnect after ACL change
+	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[1], 0));
 	FAIL_ON_ERR_THR(knet_link_rm_acl(knet_h[1], 2, 0, &ss1, &ss2, CHECK_TYPE_MASK, CHECK_REJECT));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[1], TESTNODES, 1, seconds, logfd));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[2], TESTNODES, 1, seconds, logfd));
@@ -310,6 +324,9 @@ static void test(int transport)
 	log_test(logfd, "Testing Netmask unblocked - this should get through");
 	FAIL_ON_ERR_THR(knet_send_str(knet_h[2], "1Netmask unblocked - this should get through"));
 	FAIL_ON_ERR_THR(wait_for_reply(seconds, reply_pipe[0], test_logfd));
+
+	// Re-enable ACL validation for next test
+	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[1], 1));
 
 	// Block traffic from a range
 	knet_strtoaddr("127.0.0.0", "0", &ss1, sizeof(ss1));
@@ -322,6 +339,8 @@ static void test(int transport)
 	// Unblock and check again
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[1], TESTNODES, 0, seconds, logfd));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[2], TESTNODES, 0, seconds, logfd));
+	// Disable ACL validation temporarily while nodes reconnect after ACL change
+	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[1], 0));
 	FAIL_ON_ERR_THR(knet_link_rm_acl(knet_h[1], 2, 0, &ss1, &ss2, CHECK_TYPE_RANGE, CHECK_REJECT));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[1], TESTNODES, 1, seconds, logfd));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[2], TESTNODES, 1, seconds, logfd));
@@ -330,7 +349,8 @@ static void test(int transport)
 	FAIL_ON_ERR_THR(knet_send_str(knet_h[2], "1Range unblocked - this should get through"));
 	FAIL_ON_ERR_THR(wait_for_reply(seconds, reply_pipe[0], test_logfd));
 
-	// Finish up - disable ACLS to make sure the QUIT message gets through
+	// Finish up - disable ACLs to make sure messages get through
+	// With secure-by-default (use_access_lists=1), need to disable for dynamic link without ACL
 	FAIL_ON_ERR_THR(knet_handle_enable_access_lists(knet_h[1], 0));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[1], TESTNODES, 1, seconds, logfd));
 	FAIL_ON_ERR_THR(wait_for_nodes_state(knet_h[2], TESTNODES, 1, seconds, logfd));

--- a/libknet/tests/sec_acl_link_id_spoofing.c
+++ b/libknet/tests/sec_acl_link_id_spoofing.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
+ *
+ * This software licensed under GPL-2.0+
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <time.h>
+
+#include "libknet.h"
+#include "internals.h"
+#include "onwire.h"
+#include "onwire_v1.h"
+#include "test-common.h"
+
+#define TEST_NAME "sec_acl_link_id_spoofing"
+
+/*
+ * Regression test for CVE-2026-15812: ACL bypass via link ID spoofing
+ *
+ * Validates that knet properly rejects ping packets where the link_id
+ * in the packet doesn't match the source address, preventing ACL bypass.
+ *
+ * Security model (as of CVE-2026-15812 fix):
+ * - use_access_lists is enabled by default (secure by default)
+ * - Static links: always validate against auto-configured ACL
+ * - Dynamic links:
+ *   - If use_access_lists = 1 (default): require ACL configuration
+ *   - If use_access_lists = 0: skip validation (user explicit opt-out)
+ *
+ * Attack scenarios tested (using static links):
+ * 1. ACL bypass: Packet from link 0 claiming link_id=1 (different configured link)
+ *    - Both links configured with different addresses
+ *    - Packet passes bounds/configured checks
+ *    - ACL validation rejects because source doesn't match link 1's expected address
+ * 2. Unconfigured link_id: Packet claims link_id=2 (not configured)
+ *    - Rejected by configured state check
+ * 3. Out-of-bounds link_id: Packet claims link_id >= KNET_MAX_LINK
+ *    - Rejected by bounds check
+ *
+ * Test approach:
+ * - Configure two static links with different addresses to same host
+ * - Inject packets with various spoofed link_id values
+ * - Verify each attack is rejected with appropriate log message
+ * - Verify use_access_lists defaults to enabled
+ */
+
+static int private_data;
+
+static void sock_notify(void *pvt_data,
+			int datafd,
+			int8_t channel,
+			uint8_t tx_rx,
+			int error,
+			int errorno)
+{
+	return;
+}
+
+/*
+ * Log filter callback to check for packet rejection due to ACL failure
+ * This catches link ID spoofing where source address doesn't match claimed link
+ */
+static int filter_packet_rejected(int logfd, const char *log_line, void *private_data)
+{
+	(void)logfd;
+	(void)private_data;
+
+	if (strstr(log_line, "Packet rejected")) {
+		return 1;
+	}
+	return 0;
+}
+
+/*
+ * Log filter callback to check for invalid link_id message
+ */
+static int filter_invalid_link_id(int logfd, const char *log_line, void *private_data)
+{
+	(void)logfd;
+	(void)private_data;
+
+	if (strstr(log_line, "Invalid link_id")) {
+		return 1;
+	}
+	return 0;
+}
+
+static void test_link_id_spoofing(void)
+{
+	knet_handle_t knet_h1, knet_h[2] = {0};
+	int logfd;
+	int datafd = 0;
+	int8_t channel = 0;
+	seq_num_t seq_num = 2000;
+
+	logfd = start_logging(stdout);
+
+	log_test(logfd, "Test: CVE-2026-15812 Link ID spoofing prevention (secure by default)");
+
+	/*
+	 * Set up knet handle
+	 */
+	knet_h1 = _ts_knet_handle_start(logfd, KNET_LOG_DEBUG, knet_h);
+
+	FAIL_ON_ERR(knet_handle_enable_sock_notify(knet_h1, &private_data, sock_notify));
+	FAIL_ON_ERR(knet_handle_add_datafd(knet_h1, &datafd, &channel, 0));
+	FAIL_ON_ERR(knet_host_add(knet_h1, 1));
+
+	/*
+	 * Configure two STATIC links to the same remote host with DIFFERENT IP addresses
+	 * Link 0: 127.0.0.1
+	 * Link 1: 127.0.0.2
+	 * This allows ACL to distinguish between links (ACL checks IP, not port)
+	 *
+	 * Note: Static links automatically get their dst_addr added to ACL during
+	 * knet_link_set_config(), and static links ALWAYS validate ACL regardless
+	 * of use_access_lists setting.
+	 *
+	 * With the CVE-2026-15812 fix, use_access_lists defaults to 1,
+	 * which means dynamic links without ACL would also be rejected.
+	 */
+	log_test(logfd, "Step 1: Configure two static links to same host (different IPs)");
+
+	struct sockaddr_storage lo0, lo1;
+
+	/* Allocate dynamic port for link 0, use 127.0.0.1 */
+	FAIL_ON_ERR(make_local_sockaddr(&lo0, 0, logfd));
+	FAIL_ON_ERR(knet_link_set_config(knet_h1, 1, 0, KNET_TRANSPORT_UDP, &lo0, &lo0, 0));
+	log_test(logfd, "        Link 0 configured (127.0.0.1)");
+
+	/* Allocate dynamic port for link 1, change IP to 127.0.0.2 */
+	FAIL_ON_ERR(make_local_sockaddr(&lo1, 1, logfd));
+	((struct sockaddr_in *)&lo1)->sin_addr.s_addr = htonl(0x7f000002); /* 127.0.0.2 */
+	if (knet_link_set_config(knet_h1, 1, 1, KNET_TRANSPORT_UDP, &lo1, &lo1, 0) < 0) {
+		log_test(logfd, "Cannot bind 127.0.0.2 (platform lacks full 127/8 support), skipping test");
+		_ts_knet_handle_stop_everything(knet_h, 1, logfd);
+		TEST_EXIT(PASS);
+	}
+	log_test(logfd, "        Link 1 configured (127.0.0.2)");
+
+	log_test(logfd, "Two static links configured to same host with different IPs");
+
+	/*
+	 * Test Case 1: ACL bypass via link ID spoofing
+	 * Send ping from link 0's address claiming to be link 1
+	 * Link 1 IS configured but expects packets from a different address
+	 * ACL check should reject because source doesn't match link 1's expected address
+	 */
+	log_test(logfd, "Step 2: Attack - ACL bypass via link ID spoofing");
+	log_test(logfd, "        Send from link 0 address claiming to be link 1");
+	log_test(logfd, "        Link 1 expects different address - should fail ACL check");
+
+	/* Install filter for packet rejection due to ACL */
+	install_log_filter(logfd, filter_packet_rejected, NULL);
+
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_PING, 1, 0, 1, 0, 0, seq_num, 0, NULL, 0) < 0) {
+		log_test(logfd, "*** FAIL: Failed to inject ACL bypass packet");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	test_sleep(logfd, 2);  /* Give RX thread time to process */
+
+	log_test(logfd, "Spoofed link_id packet sent");
+
+	log_test(logfd, "Step 3: Verify ACL rejected the packet");
+
+	if (!check_log_pattern_found()) {
+		log_test(logfd, "*** FAIL: ACL did not reject spoofed packet");
+		log_test(logfd, "          Expected: 'Packet rejected from'");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	log_test(logfd, "ACL correctly rejected spoofed link_id packet");
+
+	/*
+	 * Test Case 2: Send ping with unconfigured link_id (link 2 not configured)
+	 * Source address is known (link 0) but link_id in packet is not configured
+	 */
+	log_test(logfd, "Step 4: Attack - Unconfigured link_id in packet");
+	log_test(logfd, "        link_id in packet: 2 (not configured)");
+
+	/* Switch to invalid link_id filter */
+	install_log_filter(logfd, filter_invalid_link_id, NULL);
+
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_PING, 1, 0, 2, 0, 0, seq_num + 1, 0, NULL, 0) < 0) {
+		log_test(logfd, "*** FAIL: Failed to inject unconfigured link_id packet");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	test_sleep(logfd, 2);
+
+	log_test(logfd, "Unconfigured link_id packet sent");
+
+	log_test(logfd, "Step 5: Verify log contains invalid link_id warning");
+
+	if (!check_log_pattern_found()) {
+		log_test(logfd, "*** FAIL: Log does not contain expected invalid link_id warning");
+		log_test(logfd, "          Expected: 'Invalid link_id'");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	log_test(logfd, "Log contains invalid link_id rejection message");
+
+	/*
+	 * Test Case 3: Send ping with out-of-bounds link_id
+	 */
+	log_test(logfd, "Step 6: Attack - Out-of-bounds link_id");
+	log_test(logfd, "        link_id in packet: %u (>= KNET_MAX_LINK)", KNET_MAX_LINK);
+
+	/* Keep invalid link_id filter active */
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_PING, 1, 0, KNET_MAX_LINK, 0, 0, seq_num + 2, 0, NULL, 0) < 0) {
+		log_test(logfd, "*** FAIL: Failed to inject out-of-bounds ping packet");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	test_sleep(logfd, 2);
+
+	log_test(logfd, "Out-of-bounds link_id packet sent");
+
+	log_test(logfd, "Step 7: Verify log contains invalid link_id warning");
+
+	if (!check_log_pattern_found()) {
+		log_test(logfd, "*** FAIL: Log does not contain expected invalid link_id warning");
+		log_test(logfd, "          Expected: 'Invalid link_id'");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	log_test(logfd, "Log contains out-of-bounds rejection message");
+
+	/* Remove filter */
+	install_log_filter(logfd, NULL, NULL);
+
+	log_test(logfd, "=== CVE-2026-15812 Link ID spoofing prevention test PASSED ===");
+	log_test(logfd, "ACL bypass via link_id spoofing prevented");
+	log_test(logfd, "Unconfigured link_id rejected");
+	log_test(logfd, "Out-of-bounds link_id rejected");
+	log_test(logfd, "All attack vectors blocked");
+	log_test(logfd, "Note: use_access_lists is now enabled by default (secure by default)");
+
+	_ts_knet_handle_stop_everything(knet_h, 1, logfd);
+
+	TEST_EXIT(PASS);
+}
+
+int main(int argc, char *argv[])
+{
+	printf("[TEST] %s: Test ACL bypass via link ID spoofing (CVE-2026-15812)\n", TEST_NAME);
+
+	test_link_id_spoofing();
+
+	return PASS;
+}

--- a/libknet/tests/sec_frag_sequence.c
+++ b/libknet/tests/sec_frag_sequence.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.  All rights reserved.
+ *
+ * Authors: Fabio M. Di Nitto <fabbione@kronosnet.org>
+ *
+ * This software licensed under GPL-2.0+
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "libknet.h"
+#include "internals.h"
+#include "onwire.h"
+#include "onwire_v1.h"
+#include "test-common.h"
+
+#define TEST_NAME "sec_frag_sequence"
+
+/*
+ * Test for CVE-2026-15813: Fragment sequence bounds checking
+ *
+ * This test validates that the RX thread properly rejects packets with:
+ * 1. frag_seq == 0 (fragments are 1-indexed, this is invalid)
+ * 2. frag_seq > frag_num (sequence number exceeds fragment count)
+ *
+ * We use a packet injector to directly test the validation logic without
+ * requiring network-level packet manipulation.
+ */
+
+static int private_data;
+static seq_num_t next_seq_num = 1;
+
+static void sock_notify(void *pvt_data,
+			int datafd,
+			int8_t channel,
+			uint8_t tx_rx,
+			int error,
+			int errorno)
+{
+	return;
+}
+
+/*
+ * Log filter callback to check for invalid fragment sequence message
+ */
+static int filter_invalid_frag_seq(int logfd, const char *log_line, void *private_data)
+{
+	(void)logfd;
+	(void)private_data;
+
+	if (strstr(log_line, "Invalid fragment sequence")) {
+		return 1;
+	}
+	return 0;
+}
+
+/*
+ * Log filter callback to check for invalid fragment count message
+ */
+static int filter_invalid_frag_count(int logfd, const char *log_line, void *private_data)
+{
+	(void)logfd;
+	(void)private_data;
+
+	if (strstr(log_line, "Invalid fragment count")) {
+		return 1;
+	}
+	return 0;
+}
+
+/*
+ * Test invalid fragment sequences
+ */
+static void test_invalid_frag_seq(void)
+{
+	knet_handle_t knet_h1, knet_h[2] = {0};
+	int logfd;
+	int datafd = 0;
+	int8_t channel = 0;
+	struct sockaddr_storage lo;
+	char payload[100];
+
+	logfd = start_logging(stdout);
+
+	memset(payload, 'A', sizeof(payload));
+
+	log_test(logfd, "Test fragment sequence validation with malformed packets");
+
+	knet_h1 = _ts_knet_handle_start(logfd, KNET_LOG_DEBUG, knet_h);
+
+	FAIL_ON_ERR(knet_handle_enable_sock_notify(knet_h1, &private_data, sock_notify));
+	FAIL_ON_ERR(knet_handle_add_datafd(knet_h1, &datafd, &channel, 0));
+	FAIL_ON_ERR(knet_host_add(knet_h1, 1));
+	FAIL_ON_ERR(_ts_knet_link_set_config(knet_h1, 1, 0, KNET_TRANSPORT_UDP, 0, AF_INET, 0, &lo, logfd));
+	FAIL_ON_ERR(knet_link_set_enable(knet_h1, 1, 0, 1));
+	FAIL_ON_ERR(knet_handle_setfwd(knet_h1, 1));
+	FAIL_ON_ERR(wait_for_host(knet_h1, 1, 10, logfd));
+
+	log_test(logfd, "Test 1: Inject packet with frag_seq=0 (should be rejected)");
+	log_test(logfd, "        Fragments are 1-indexed, so frag_seq=0 is invalid");
+
+	/* Install log filter to catch rejection message */
+	install_log_filter(logfd, filter_invalid_frag_seq, NULL);
+
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_DATA, 1, 0, 0, 2, 0, next_seq_num++, 0, payload, 50) < 0) {
+		log_test(logfd, "Failed to inject packet with frag_seq=0");
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	/* Give RX thread time to process and log thread to catch it */
+	test_sleep(logfd, 2);
+
+	if (!check_log_pattern_found()) {
+		log_test(logfd, "*** FAIL: Expected log 'Invalid fragment sequence' not found");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+	log_test(logfd, "Test 1 PASSED: Invalid frag_seq=0 was rejected");
+
+	log_test(logfd, "Test 2: Inject packet with frag_seq > frag_num (should be rejected)");
+	log_test(logfd, "        frag_seq=5 but frag_num=2 (sequence exceeds count)");
+
+	/* Filter still installed, reset flag */
+	install_log_filter(logfd, filter_invalid_frag_seq, NULL);
+
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_DATA, 1, 0, 0, 2, 5, next_seq_num++, 0, payload, 50) < 0) {
+		log_test(logfd, "Failed to inject packet with frag_seq > frag_num");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	test_sleep(logfd, 2);
+
+	if (!check_log_pattern_found()) {
+		log_test(logfd, "*** FAIL: Expected log 'Invalid fragment sequence' not found");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+	log_test(logfd, "Test 2 PASSED: Invalid frag_seq > frag_num was rejected");
+
+	log_test(logfd, "Test 3: Inject valid fragment packet (should be accepted)");
+	log_test(logfd, "        frag_seq=1, frag_num=1 (valid unfragmented packet)");
+
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_DATA, 1, 0, 0, 1, 1, next_seq_num++, 0, payload, 50) < 0) {
+		log_test(logfd, "Failed to inject valid packet");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	test_sleep(logfd, 1);
+	log_test(logfd, "Test 3 PASSED: Valid packet was accepted (no rejection log)");
+
+	log_test(logfd, "Test 4: Inject packet with frag_num=255 (maximum value, should be rejected)");
+	log_test(logfd, "        frag_map array has 255 elements (indices 0-254)");
+	log_test(logfd, "        frag_seq=255 would access frag_map[255] which is out of bounds");
+
+	/* Install filter for fragment count validation */
+	install_log_filter(logfd, filter_invalid_frag_count, NULL);
+
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_DATA, 1, 0, 0, 255, 255, next_seq_num++, 0, payload, 50) < 0) {
+		log_test(logfd, "Failed to inject packet with frag_num=255");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	test_sleep(logfd, 2);
+
+	if (!check_log_pattern_found()) {
+		log_test(logfd, "*** FAIL: Expected log 'Invalid fragment count' not found");
+		install_log_filter(logfd, NULL, NULL);
+		TEST_EXIT_CLEAN(FAIL);
+	}
+	log_test(logfd, "Test 4 PASSED: frag_num=255 was rejected (prevents array overflow)");
+
+	log_test(logfd, "Test 5: Inject packet with frag_num=254 (maximum valid, should be accepted)");
+	log_test(logfd, "        Valid range is 1-254, this tests the boundary");
+
+	/* Remove filter so we can verify no rejection */
+	install_log_filter(logfd, NULL, NULL);
+
+	/* Send complete packet with frag_num=254, frag_seq=1 (first of 254 fragments) */
+	if (inject_packet(knet_h1, KNET_HEADER_TYPE_DATA, 1, 0, 0, 254, 1, next_seq_num++, 0, payload, 50) < 0) {
+		log_test(logfd, "Failed to inject packet with frag_num=254");
+		TEST_EXIT_CLEAN(FAIL);
+	}
+
+	test_sleep(logfd, 1);
+	log_test(logfd, "Test 5 PASSED: frag_num=254 was accepted (maximum valid value)");
+
+	/* Remove filter */
+	install_log_filter(logfd, NULL, NULL);
+
+	log_test(logfd, "=== CVE-2026-15813 Fragment sequence validation test PASSED ===");
+	log_test(logfd, "Invalid frag_seq values were properly rejected");
+	log_test(logfd, "Invalid frag_num=255 was rejected (prevents array overflow)");
+	log_test(logfd, "Valid frag_num=254 was accepted (maximum valid value)");
+	log_test(logfd, "Valid fragment packets were accepted");
+	log_test(logfd, "Heap buffer overflow prevented");
+
+	_ts_knet_handle_stop_everything(knet_h, 1, logfd);
+
+	TEST_EXIT(PASS);
+}
+
+int main(int argc, char *argv[])
+{
+	printf("[TEST] %s: Test fragment sequence bounds checking (CVE-2026-15813)\n", TEST_NAME);
+
+	test_invalid_frag_seq();
+
+	return PASS;
+}

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -884,23 +884,71 @@ static void _handle_dynip(knet_handle_t knet_h, struct knet_host *src_host, stru
  */
 static int _check_rx_acl(knet_handle_t knet_h, struct knet_link *src_link, const struct knet_mmsghdr *msg)
 {
-	if (knet_h->use_access_lists) {
-		if (!check_validate(knet_h, src_link, msg->msg_hdr.msg_name)) {
-			char src_ipaddr[KNET_MAX_HOST_LEN];
-			char src_port[KNET_MAX_PORT_LEN];
+	const struct sockaddr_storage *src_addr = msg->msg_hdr.msg_name;
+	char src_ipaddr[KNET_MAX_HOST_LEN];
+	char src_port[KNET_MAX_PORT_LEN];
+	int has_acl;
 
-			memset(src_ipaddr, 0, KNET_MAX_HOST_LEN);
-			memset(src_port, 0, KNET_MAX_PORT_LEN);
-			if (knet_addrtostr(msg->msg_hdr.msg_name, sockaddr_len(msg->msg_hdr.msg_name),
+	/*
+	 * ACL validation to prevent link ID spoofing (CVE-2026-15812)
+	 *
+	 * Static links (KNET_LINK_STATIC):
+	 *   Always validate - dst_addr is auto-configured in ACL during knet_link_set_config()
+	 *
+	 * Dynamic links (KNET_LINK_DYNIP):
+	 *   - If use_access_lists = 0: skip validation (user explicitly disabled)
+	 *   - If use_access_lists = 1 (default):
+	 *     - If no ACL configured: reject with specific message
+	 *     - If ACL configured: validate source address
+	 *
+	 * This ensures all links require proper ACL configuration unless explicitly opted out.
+	 */
+
+	if (src_link->dynamic == KNET_LINK_STATIC) {
+		/* Static links: always validate */
+		if (!check_validate(knet_h, src_link, (struct sockaddr_storage *)src_addr)) {
+			if (knet_addrtostr(src_addr, sockaddr_len(src_addr),
 					   src_ipaddr, KNET_MAX_HOST_LEN,
 					   src_port, KNET_MAX_PORT_LEN) < 0) {
-
 				log_warn(knet_h, KNET_SUB_RX, "Packet rejected: unable to resolve host/port");
 			} else {
 				log_warn(knet_h, KNET_SUB_RX, "Packet rejected from %s:%s", src_ipaddr, src_port);
 			}
 			return 0;
 		}
+	} else {
+		/* Dynamic links */
+		if (knet_h->use_access_lists) {
+			/* Check if link has ACL configured */
+			has_acl = (src_link->access_list_match_entry_head != NULL) &&
+				  (*(void **)src_link->access_list_match_entry_head != NULL);
+
+			if (!has_acl) {
+				/* No ACL configured - reject */
+				if (knet_addrtostr(src_addr, sockaddr_len(src_addr),
+						   src_ipaddr, KNET_MAX_HOST_LEN,
+						   src_port, KNET_MAX_PORT_LEN) < 0) {
+					log_warn(knet_h, KNET_SUB_RX, "Packet rejected: dynamic link has no ACL configured");
+				} else {
+					log_warn(knet_h, KNET_SUB_RX, "Packet rejected from %s:%s: dynamic link has no ACL configured",
+						 src_ipaddr, src_port);
+				}
+				return 0;
+			}
+
+			/* ACL configured - validate */
+			if (!check_validate(knet_h, src_link, (struct sockaddr_storage *)src_addr)) {
+				if (knet_addrtostr(src_addr, sockaddr_len(src_addr),
+						   src_ipaddr, KNET_MAX_HOST_LEN,
+						   src_port, KNET_MAX_PORT_LEN) < 0) {
+					log_warn(knet_h, KNET_SUB_RX, "Packet rejected: unable to resolve host/port");
+				} else {
+					log_warn(knet_h, KNET_SUB_RX, "Packet rejected from %s:%s", src_ipaddr, src_port);
+				}
+				return 0;
+			}
+		}
+		/* else: use_access_lists = 0, skip validation */
 	}
 	return 1;
 }
@@ -972,6 +1020,14 @@ static void _parse_recv_from_links(knet_handle_t knet_h, int sockfd, const struc
 					return;
 					break;
 			}
+		}
+
+		/*
+		 * Validate link_id bounds and configuration (CVE-2026-15812)
+		 * Logging is done in get_link_from_pong_v1() to distinguish failure cases
+		 */
+		if (!src_link) {
+			return;
 		}
 		if (!_check_rx_acl(knet_h, src_link, msg)) {
 			return;

--- a/libknet/threads_rx.c
+++ b/libknet/threads_rx.c
@@ -336,6 +336,33 @@ static int _pckt_defrag(knet_handle_t knet_h, struct knet_host *src_host, seq_nu
 	struct knet_host_defrag_buf *defrag_buf;
 	int defrag_buf_idx;
 
+	/*
+	 * Validate total fragment count
+	 * frag_map array has PCKT_FRAG_MAX (255) elements indexed 0-254.
+	 * Since frag_seq is 1-based and used as array index, maximum valid
+	 * value is PCKT_FRAG_MAX-1 (254).
+	 */
+	if (frags == 0 || frags >= PCKT_FRAG_MAX) {
+		log_warn(knet_h, KNET_SUB_RX,
+			 "Invalid fragment count: %u (valid range: 1-%u)",
+			 frags, PCKT_FRAG_MAX - 1);
+		errno = EINVAL;
+		return -1;
+	}
+
+	/*
+	 * Validate fragment sequence number to prevent buffer overflow.
+	 * frag_seq is used as array index into frag_map[PCKT_FRAG_MAX].
+	 * Also ensure frag_seq is within the declared fragment count.
+	 */
+	if (frag_seq == 0 || frag_seq > frags) {
+		log_warn(knet_h, KNET_SUB_RX,
+			 "Invalid fragment sequence %u (total frags: %u)",
+			 frag_seq, frags);
+		errno = EINVAL;
+		return -1;
+	}
+
 	defrag_buf_idx = _find_pckt_defrag_buf(knet_h, src_host, seq_num);
 	if (defrag_buf_idx < 0) {
 		return 1;


### PR DESCRIPTION
## Summary

- **CVE-2026-15811** (LOW): encryption key exposure in memory after cryptographic configuration changes — wipe crypto keys with explicit_bzero() before freeing ([BZ#2500850](https://bugzilla.redhat.com/show_bug.cgi?id=2500850))
- **CVE-2026-15812** (LOW): access control list bypass via link ID spoofing on unencrypted dynamic links — validate source address against link_id, enable ACLs by default ([BZ#2500852](https://bugzilla.redhat.com/show_bug.cgi?id=2500852))
- **CVE-2026-15813** (MEDIUM): memory corruption and out-of-bounds access via malformed network packet defragmentation — bounds check fragment sequence numbers before buffer access ([BZ#2500864](https://bugzilla.redhat.com/show_bug.cgi?id=2500864))