### PR TITLE
rust: nozzle: allow empty path to nozzle::open()

### DIFF
--- a/libnozzle/bindings/rust/src/nozzle_bindings.rs
+++ b/libnozzle/bindings/rust/src/nozzle_bindings.rs
@@ -46,10 +46,18 @@ pub fn open(devname: &mut String, updownpath: &str) -> Result<Handle>
     let c_devname_size = IFNAMSZ;
 
     crate::string_to_bytes(devname, &mut c_devname)?;
-    crate::string_to_bytes(updownpath, &mut c_updownpath)?;
+
+    // If the string is empty then pass NULL to nozzle_open
+    // to indicate that no path is required.
+    let updownpath_ptr = if updownpath.is_empty() {
+        std::ptr::null()
+    } else {
+        crate::string_to_bytes(updownpath, &mut c_updownpath)?;
+        c_updownpath.as_ptr()
+    };
 
     let res = unsafe {
-	ffi::nozzle_open(c_devname.as_mut_ptr(), c_devname_size, c_updownpath.as_ptr())
+	ffi::nozzle_open(c_devname.as_mut_ptr(), c_devname_size, updownpath_ptr)
     };
 
     if res.is_null() {

--- a/libnozzle/bindings/rust/tests/src/bin/nozzle-test.rs
+++ b/libnozzle/bindings/rust/tests/src/bin/nozzle-test.rs
@@ -24,6 +24,23 @@ fn main() -> Result<()>
 	std::process::exit(SKIP);
     }
 
+    // Test an empty dirname
+    let mut nozzle_name = String::from("tap0");
+    let handle = match nozzle::open(&mut nozzle_name, "") {
+	Ok(h) => {
+	    println!("Opened device specified {nozzle_name} with empty path");
+	    h
+	},
+	Err(e) => {
+	    println!("Error opening {nozzle_name} with no path: {e}");
+	    return Err(e);
+	}
+    };
+    if let Err(e) = nozzle::close(&handle) {
+	println!("Error from close: {e}");
+	return Err(e);
+    }
+
     // Run in a random tmpdir so we don't clash with other instances
     let tmp_path = tempdir()?;
     let tmp_dir = match tmp_path.path().to_str() {


### PR DESCRIPTION
It indicates no path is needed and should pass NULL into the C API